### PR TITLE
minor change and nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ the run-on-boot feature of joy (and many other programs that
 relied on /System/Library/LaunchDaemons), so for now that program
 can only perform live capture from the command line.
 
-Set COMPRESSED_OUTPUT (in src/output.h) to 1 for gzip-compressed
+Set COMPRESSED_OUTPUT (in src/include/output.h) to 1 for gzip-compressed
 JSON output. This compile-time option is on by default. If that
 \#define is instead set to 0, then normal JSON will be output.
 There are many tools that can be used to work with gzip-compressed

--- a/config
+++ b/config
@@ -5,8 +5,8 @@
 #    Valid options are:
 #         -h | --help           - Help screen
 #         -l | --lib-path       - specify the library path
-#         -s | --ssl-path       - speacify the OpenSSL header path
-#         -c | --curl-path      - speacify the Curl header path
+#         -s | --ssl-path       - specify the OpenSSL header path
+#         -c | --curl-path      - specify the Curl header path
 ##
 print_usage ()
 {
@@ -44,6 +44,16 @@ string_has ()
 ##
 find_ssl_headers ()
 {
+    if [ $1 ]; then
+        ssl_crypto=`find "$1" -name "crypto.h" 2>/dev/null | grep "openssl" | head -1`
+        if [ "$ssl_crypto" != "" ]; then
+           echo "Searching for OpenSSL headers...found"
+           ## remove /openssl/crypto.h from the end of the path
+           ssl_crypto_path=${ssl_crypto::${#ssl_crypto}-17}
+           return
+        fi
+    fi
+
     ssl_crypto=`find /usr -name "crypto.h" 2>/dev/null | grep "openssl" | head -1`
     if [ "$ssl_crypto" != "" ]; then
         echo "Searching for OpenSSL headers...found"
@@ -66,16 +76,6 @@ find_ssl_headers ()
         ## remove /openssl/crypto.h from the end of the path
         ssl_crypto_path=${ssl_crypto::${#ssl_crypto}-17}
         return
-    fi
-
-    if [ $1 ]; then
-        ssl_crypto=`find "$1" -name "crypto.h" 2>/dev/null | grep "openssl" | head -1`
-        if [ "$ssl_crypto" != "" ]; then
-           echo "Searching for OpenSSL headers...found"
-           ## remove /openssl/crypto.h from the end of the path
-           ssl_crypto_path=${ssl_crypto::${#ssl_crypto}-17}
-           return
-        fi
     fi
 
     if [ $1 ]; then


### PR DESCRIPTION
Some typos and nits.
The reordering change in find_ssl_headers was because the -s was not working. When I had more than one SSL header files like 
```
/usr/local/include/cyassl/openssl/crypto.h
/usr/local/include/wolfssl/openssl/crypto.h
/usr/include/openssl/crypto.h

``` 
it was not paying attention to my -s option and was also using only the first header find it could find. 