### PR TITLE
Update joy.c

### DIFF
--- a/src/joy.c
+++ b/src/joy.c
@@ -908,14 +908,8 @@ int main (int argc, char **argv) {
            }
 
            /* print out inactive flows */
-#ifdef WIN32
-		   DWORD t;
-		   t = timeGetTime();
-		   time_of_day.tv_sec = t / 1000;
-		   time_of_day.tv_usec = t % 1000;
-#else
-		   gettimeofday(&time_of_day, NULL);
-#endif
+	   gettimeofday(&time_of_day, NULL);
+
            timer_sub(&time_of_day, &time_window, &inactive_flow_cutoff);
 
            flow_record_list_print_json(&inactive_flow_cutoff);


### PR DESCRIPTION
We can use gettimeofday in Windows too, but if we use timeGetTime it return the system time, in milliseconds，and is not what we want
see MSDN
Note that the value returned by the timeGetTime function is a DWORD value. The return value wraps around to 0 every 2^32 milliseconds, which is about 49.71 days

https://msdn.microsoft.com/query/dev15.query?appId=Dev15IDEF1&l=ZH-CN&k=k(%22TIMEAPI%2FtimeGetTime%22);k(timeGetTime);k(DevLang-C%2B%2B);k(TargetOS-Windows)&rd=true