### PR TITLE
Mac OSX package upgrade cleanup

### DIFF
--- a/build_pkg
+++ b/build_pkg
@@ -6,7 +6,7 @@
 usage() { 
     echo "usage:"
     echo ""
-    echo "   $0 [ [ -h ] | [ -t deb|osxpkg|rpm ] [ -r git-reference ] [ -R release ]"
+    echo "   $0 [ [ -h ] | [ -t deb|osxpkg|rpm ] [ -r git-reference ] [ -R release ] [ -s ssl-path ]"
     echo ""
     echo "where the options are as follows"
     echo ""
@@ -19,6 +19,9 @@ usage() {
     echo ""
     echo "   The -R release specifies number preceding the short git commit to allow for"
     echo "   package upgrades on the same joy version."
+    echo ""
+    echo "   The -s ssl-path is required when building osxpkg and specifies the"
+    echo "   location of the OpenSSL header files."
     echo ""
 } 
 
@@ -41,7 +44,6 @@ UBUNTU_REQS="-d libcurl3 -d libpcap0.8 -d libssl1.0.0"
 MAC_PKGS="gcc gem git make python ruby"
 RPM_PKGS="gcc git libcurl libcurl-devel libpcap libpcap-devel make openssl \
     openssl-devel python python2-pip ruby rubygems zlib zlib-devel"
-OSREL=`lsb_release -is | tr '[:upper:]' '[:lower:]'`
 ARCH=`uname -m`
 
 echo
@@ -51,7 +53,7 @@ echo
 
 # check command line arguments, ovveride defaults as appropriate
 #
-while getopts "ht:r:R:" arg; do
+while getopts "ht:s:r:R:" arg; do
     case $arg in
     h)
         usage
@@ -60,6 +62,10 @@ while getopts "ht:r:R:" arg; do
     t)
         echo "-t was triggered with option ${OPTARG}" 
         BUILDTYPE=${OPTARG}
+        ;;
+    s)
+        echo "-s was triggered with option ${OPTARG}" 
+        SSL_PATH=${OPTARG}
         ;;
     r)
         echo "-r was triggered with option ${OPTARG}" 
@@ -88,6 +94,13 @@ if [ $(($# + 1)) != "${OPTIND}" ]; then
 fi
 if [ -z "$BUILDTYPE" ]; then
     echo "-t deb|osxpkg|rpm must be specified" >&2
+    exit 1
+fi
+if [ "$BUILDTYPE" != "osxpkg" ]; then
+    OSREL=`lsb_release -is | tr '[:upper:]' '[:lower:]'`
+elif [ -z "$SSL_PATH" ]; then
+    echo "When building joy on OSX, you must specify the -s ssl-path option"
+    echo "with the location of the OpenSSL header files."
     exit 1
 fi
 if [ -n "$RELEASE" ]; then
@@ -267,7 +280,7 @@ if [ "$BUILDTYPE" == "deb" ]; then
         exit 1
     fi
 elif [ "$BUILDTYPE" == "osxpkg" ]; then
-    ./config
+    ./config --ssl-path $SSL_PATH
 elif [ "$BUILDTYPE" == "rpm" ]; then
     ./config -l /usr/lib64
 fi

--- a/build_pkg
+++ b/build_pkg
@@ -28,7 +28,9 @@ usage() {
 # set defaults
 #
 NAME=joy
-VERSION=`cat VERSION`
+# Subtract .01 from VERSION file in git to build packages since the VERSION file
+# contains the next version number for joy, not the current version.
+VERSION=`echo "scale = 2; \`cat VERSION\` - .01" | bc`
 GITREF=master
 CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT=$(dirname "$CWD")
@@ -230,6 +232,7 @@ FPM_LINUX_OPTIONS="-C $BUILDROOT -n $NAME -v $VERSION --iteration $ITERATION \
     --url https://github.com/cisco/joy"
 FPM_MAC_OPTIONS="-C $BUILDROOT -n $NAME -v $VERSION-$ITERATION \
     --after-install $APP_ROOT/joy/install/postinstall-darwin \
+    --before-install $APP_ROOT/joy/install/preinstall-darwin \
     --vendor Cisco \
     --osxpkg-identifier-prefix com.cisco \
     --osxpkg-dont-obsolete /usr/local/etc/joy/ \
@@ -246,8 +249,8 @@ if [ "$?" != 0 ]; then
 fi
 # Used for pkg development; grab files not yet checked-in to master
 if [ "$GITREF" != "master" ]; then
-    tar -f $TAR_FILE --delete joy/Makefile joy/install/install-sh
-    tar -uf $TAR_FILE -C .. joy/Makefile joy/install/install-sh
+    tar -f $TAR_FILE --delete joy/Makefile joy/install/install-sh joy/install/postinstall-darwin joy/install/preinstall-darwin 2>/dev/null
+    tar -uf $TAR_FILE -C .. joy/Makefile joy/config joy/install/install-sh joy/install/postinstall-darwin joy/install/preinstall-darwin
     if [ "$?" != 0 ]; then
         echo Failed to update archive tar
         rmdir $TMPDIR

--- a/build_pkg
+++ b/build_pkg
@@ -100,10 +100,13 @@ if [ -z "$BUILDTYPE" ]; then
 fi
 if [ "$BUILDTYPE" != "osxpkg" ]; then
     OSREL=`lsb_release -is | tr '[:upper:]' '[:lower:]'`
-elif [ -z "$SSL_PATH" ]; then
-    echo "When building joy on OSX, you must specify the -s ssl-path option"
-    echo "with the location of the OpenSSL header files."
-    exit 1
+elif [ "$BUILDTYPE" == "osxpkg" ]; then
+    OSXVER=`sw_vers -productVersion | awk -F. '{print $1"."$2}'`
+    if [ -z "$SSL_PATH" ]; then
+        echo "When building joy on OSX, you must specify the -s ssl-path option"
+        echo "with the location of the OpenSSL header files."
+        exit 1
+    fi
 fi
 if [ -n "$RELEASE" ]; then
     if [ ${RELEASE} -eq ${RELEASE} ] 2>/dev/null; then
@@ -213,6 +216,8 @@ ITERATION="${RELEASE}.${SHORT_COMMIT_ID}"
 if [ "$OSREL" == "debian" -o "$OSREL" == "ubuntu" ]; then
     CODENAME=`lsb_release -cs`
     ITERATION="$ITERATION.$CODENAME"
+elif [ -n "$OSXVER" ]; then
+    ITERATION="$ITERATION.macosx.$OSXVER"
 fi
 FULL_VERSION="${VERSION}-${ITERATION}"
 TAR_FILE=`pwd`/joy-$SHORT_COMMIT_ID.tar

--- a/config
+++ b/config
@@ -282,5 +282,6 @@ else
 fi
 echo "export CURLPATH= -I \"$curl_header_path\"" >> config.vars
 
+echo "The following variables were defined:"
+cat config.vars
 echo "All dependencies found. Issue 'make clean;make' to build the code"
-

--- a/install/install-sh
+++ b/install/install-sh
@@ -244,7 +244,20 @@ if [ "$sysname" == "Darwin" ]; then
         echo "Running pip install ${APP_ROOT}/sleuth/"
         pip install ${APP_ROOT}/sleuth/
     else
-        pip install -t $PREFIX/lib/python ${APP_ROOT}/sleuth/
+	cd ${APP_ROOT}/sleuth
+	echo "Running python setup.py bdist --format=gztar"
+	python setup.py bdist --format=gztar
+        if [ $retval -ne "0" ]; then
+            echo "error: could not run python setup.py for sleuth"
+            exit 1
+        fi
+        SLEUTHFILE="${APP_ROOT}/sleuth/dist/sleuth-0.1.macosx-10.12-intel.tar.gz"
+	if [ -f $SLEUTHFILE ]; then
+            tar -xf $SLEUTHFILE -C $BUILDROOT
+	else
+            echo "Cannot find sleuth tarball $SLEUTHFILE"
+            exit 1
+	fi
     fi
 
     # Install the configuration file

--- a/install/install-sh
+++ b/install/install-sh
@@ -189,7 +189,8 @@ if [ "$sysname" == "Darwin" ]; then
     ##
     # Darwin operating system detected
     ##
-    echo "found $sysname (Mac OS X), installing joy ..."
+    OSXVER=`sw_vers -productVersion | awk -F. '{print $1"."$2}'`
+    echo "found $sysname (Mac OS X $OSXVER), installing joy ..."
 
     if [ -z "$PKGBUILD" ]; then
         echo "stopping flow capture daemon (just in case one is already running)"
@@ -245,13 +246,14 @@ if [ "$sysname" == "Darwin" ]; then
         pip install ${APP_ROOT}/sleuth/
     else
 	cd ${APP_ROOT}/sleuth
+	SLEUTHVER=`grep version setup.py | awk -F\' '{print $2}'`
 	echo "Running python setup.py bdist --format=gztar"
 	python setup.py bdist --format=gztar
         if [ $retval -ne "0" ]; then
             echo "error: could not run python setup.py for sleuth"
             exit 1
         fi
-        SLEUTHFILE="${APP_ROOT}/sleuth/dist/sleuth-0.1.macosx-10.12-intel.tar.gz"
+        SLEUTHFILE="${APP_ROOT}/sleuth/dist/sleuth-${SLEUTHVER}.macosx-${OSXVER}-intel.tar.gz"
 	if [ -f $SLEUTHFILE ]; then
             tar -xf $SLEUTHFILE -C $BUILDROOT
 	else
@@ -446,13 +448,14 @@ elif [ "$sysname" == "Linux" ]; then
         pip install ${APP_ROOT}/sleuth/
     else
 	cd ${APP_ROOT}/sleuth
+	SLEUTHVER=`grep version setup.py | awk -F\' '{print $2}'`
 	echo "Running python setup.py bdist --format=gztar"
 	python setup.py bdist --format=gztar
         if [ $retval -ne "0" ]; then
             echo "error: could not run python setup.py for sleuth"
             exit 1
         fi
-        SLEUTHFILE="${APP_ROOT}/sleuth/dist/sleuth-0.1.linux-${ARCH}.tar.gz"
+        SLEUTHFILE="${APP_ROOT}/sleuth/dist/sleuth-${SLEUTHVER}.linux-${ARCH}.tar.gz"
 	if [ -f $SLEUTHFILE ]; then
             tar -xf $SLEUTHFILE -C $BUILDROOT
 	else

--- a/install/joy.plist
+++ b/install/joy.plist
@@ -1,33 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-
 <plist version="1.0">
-
 <dict>
-
     <key>Label</key>
-
-    <string>org.p2f.joy</string>
-
+    <string>com.cisco.joy</string>
     <key>ProgramArguments</key>
-
     <array>
-
         <string>/usr/local/bin/joy</string>
-
         <string>-x</string>
-
         <string>/usr/local/etc/joy/options.cfg</string>
-
     </array>
-
     <key>KeepAlive</key>
-
     <true/>
-
 </dict>
-
 </plist>
-
- 

--- a/install/postinstall-darwin
+++ b/install/postinstall-darwin
@@ -10,12 +10,24 @@ exec >> $LOGFILE 2>&1
 launchctl unload "$LAUNCH_AGENT_DEST" || true
 rm -f "$LAUNCH_AGENT_DEST" || true
 
+# Restore key configuration files
+for file in /usr/local/etc/joy/upload-key /usr/local/etc/joy/upload-key.pub \
+	/usr/local/etc/joy/options.cfg /usr/local/etc/joy/internal.net; do
+	if [ -f ${file}.previous-install ]; then
+		echo "Restoring ${file}.previous-install to $file"
+    		mv -f ${file}.previous-install $file
+	else
+		echo "Unable to find $file for backup"
+	fi
+done
+
+if [ ! -f /usr/local/etc/joy/upload-key ]; then
+	echo "Generating new upload-key"
+        ssh-keygen -f /usr/local/etc/joy/upload-key -P "" -t rsa -b 2048 || true
+fi
+
 # Install launch agent
 cp "$LAUNCH_AGENT_SRC" "$LAUNCH_AGENT_DEST" || true
 launchctl load "$LAUNCH_AGENT_DEST" || true
-
-if [ ! -f /usr/local/etc/joy/upload-key ]; then
-        ssh-keygen -f /usr/local/etc/joy/upload-key -P "" -t rsa -b 2048 || true
-fi
 
 exit 0

--- a/install/postinstall-darwin
+++ b/install/postinstall-darwin
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-set -e
 
 # Launch agent location
-LAUNCH_AGENT_SRC="/usr/local/joy/etc/joy.plist"
+LAUNCH_AGENT_SRC="/usr/local/etc/joy/joy.plist"
 LAUNCH_AGENT_DEST="/Library/LaunchAgents/com.cisco.joy.plist"
+LOGFILE="/usr/local/var/log/joy-postinstall.log"
+exec >> $LOGFILE 2>&1 
 
 # Uninstall old launch agent
 launchctl unload "$LAUNCH_AGENT_DEST" || true

--- a/install/preinstall-darwin
+++ b/install/preinstall-darwin
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Launch agent location
+LAUNCH_AGENT_SRC="/usr/local/etc/joy/joy.plist"
+LAUNCH_AGENT_DEST="/Library/LaunchAgents/com.cisco.joy.plist"
+LOGFILE="/usr/local/var/log/joy-preinstall.log"
+exec >> $LOGFILE 2>&1 
+
+# Uninstall old launch agent
+#launchctl unload "$LAUNCH_AGENT_DEST" || true
+#rm -f "$LAUNCH_AGENT_DEST" || true
+
+# Backup key configuration files
+for file in /usr/local/etc/joy/upload-key /usr/local/etc/joy/upload-key.pub \
+	/usr/local/etc/joy/options.cfg /usr/local/etc/joy/internal.net; do
+	if [ -f $file ]; then
+		echo "Backing up $file to ${file}.previous-install"
+    		cp -a $file ${file}.previous-install
+	fi
+done
+
+exit 0


### PR DESCRIPTION
Various improvements to build joy on Mac OSX including specifying path to OpenSSL headers and pre- and post-install scripts to keep user-modified configuration files from being overwritten upon package upgrades.