### PR TITLE
modify BZIP2 printf to account for large output strings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,8 +25,10 @@ LIBS += -lpthread # thread library; used in updater thread
 
 ifeq ($(COMPDEF),-DUSE_BZIP2)
 LIBS += -lbz2     # bzip2 library
-else if ($(COMPDEF),-DUSE_GZIP)
-LIBS += -lz       # gzip library
+else
+  ifeq ($(COMPDEF),-DUSE_GZIP)
+    LIBS += -lz       # gzip library
+  endif
 endif
 
 ##

--- a/src/utils.c
+++ b/src/utils.c
@@ -59,24 +59,43 @@ extern char *aux_resource_path;
  * doesn't have a printf interface, so an equivalent
  * interface needed to be written.
  * Note: this function can only output 512 chars at a time.
- *   if a string comes through bigger than 512, it will be
- *   truncated. Perhaps this can be optimized in the future.
+ *   if a string comes through bigger than 512, it will
+ *   dynamically allocate a buffer to hold the output and then
+ *   print out the data.
  *
  */
 #define BZ_MAX_SIZE 512
+char BZ_buff[BZ_MAX_SIZE];
 int BZ2_bzprintf(BZFILE *b, const char * format, ...)
 {
     int BZ_sz; 
     int BZ_errnum;
     va_list arg;
-    char BZ_buff[BZ_MAX_SIZE]; 
 
     va_start(arg, format);
-    BZ_sz = vsnprintf(BZ_buff, BZ_MAX_SIZE, format, arg); 
+    BZ_sz = vsnprintf(BZ_buff, BZ_MAX_SIZE, format, arg);
     va_end(arg);
-    BZ2_bzwrite(b, BZ_buff, BZ_sz); 
+
+    /* check resulting size and perform output accordingly */
+    if (BZ_sz >= BZ_MAX_SIZE) {
+        char *BZ_dyn_buff = malloc(BZ_sz + 1);
+        if (BZ_dyn_buff != NULL) {
+            va_start(arg, format);
+            BZ_sz = vsnprintf(BZ_dyn_buff, (BZ_sz + 1), format, arg);
+            va_end(arg);
+            BZ2_bzwrite(b, BZ_dyn_buff, BZ_sz);
+            free(BZ_dyn_buff);
+        } else {
+            /* error scenario, can't print out all the data,
+             * let's just print what we can
+             */
+            BZ2_bzwrite(b, BZ_buff, (BZ_MAX_SIZE-1));
+        }
+    } else {
+        BZ2_bzwrite(b, BZ_buff, BZ_sz);
+    }
     BZ2_bzerror(b, &BZ_errnum);
-    return BZ_errnum;      
+    return BZ_errnum;
 }
 #endif
 


### PR DESCRIPTION
modify BZIP2 printf to account for large output strings