### PR TITLE
Joy drops root privileges to joy user in online packet-capture mode

### DIFF
--- a/build_pkg
+++ b/build_pkg
@@ -285,8 +285,8 @@ if [ "$?" != 0 ]; then
 fi
 # Used for pkg development; grab files not yet checked-in to master
 if [ "$GITREF" != "master" ]; then
-    tar -f $TAR_FILE --delete joy/src/joy.c joy/install/preinstall-linux 2>/dev/null
-    tar -uvf $TAR_FILE -C .. joy/src/joy.c joy/install/preinstall-linux
+    tar -f $TAR_FILE --delete joy/install/install-sh 2>/dev/null
+    tar -rvf $TAR_FILE -C .. joy/src/joy.c joy/install/install-sh joy/install/postinstall-darwin joy/install/preinstall-darwin
     if [ "$?" != 0 ]; then
         echo Failed to update archive tar
         rmdir $TMPDIR
@@ -355,13 +355,12 @@ if [ "$BUILDTYPE" == "deb" ]; then
     fpm -s dir -t deb $FPM_LINUX_OPTIONS $FPM_REQS \
         -d "python >= 2.7" \
         --deb-no-default-config-files \
-        --description 'Joy is a libpcap-based software package for extracting data features from live
+        --description "Joy is a libpcap-based software package for extracting data features from live
 network traffic or packet capture \(pcap\) files, using a flow-oriented model
 similar to that of IPFIX or Netflow, and then representing these data features
 in JSON. It also contains analysis tools that can be applied to these data
 files. Joy can be used to explore data at scale, especially security and
-threat-relevant data.' \
-        --summary "Capture and analyze network flow data for research, forensics and monitoring. (Compression: $COMPRESSION)" \
+threat-relevant data. (Compression: $COMPRESSION)" \
         ./
     if [ "$?" != 0 ]; then
         echo Failed to build deb
@@ -369,13 +368,12 @@ threat-relevant data.' \
     fi
 elif [ "$BUILDTYPE" == "osxpkg" ]; then
     fpm -s dir -t osxpkg $FPM_MAC_OPTIONS \
-        --description 'Joy is a libpcap-based software package for extracting data features from live
-network traffic or packet capture (pcap) files, using a flow-oriented model
+        --description "Joy is a libpcap-based software package for extracting data features from live
+network traffic or packet capture \(pcap\) files, using a flow-oriented model
 similar to that of IPFIX or Netflow, and then representing these data features
 in JSON. It also contains analysis tools that can be applied to these data
 files. Joy can be used to explore data at scale, especially security and
-threat-relevant data.' \
-        --summary "Capture and analyze network flow data for research, forensics and monitoring. (Compression: $COMPRESSION)" \
+threat-relevant data. (Compression: $COMPRESSION)" \
         ./
     if [ "$?" != 0 ]; then
         echo Failed to build OS X pkg

--- a/build_pkg
+++ b/build_pkg
@@ -39,18 +39,17 @@ COMPRESSION=gzip
 CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_ROOT=$(dirname "$CWD")
 PROGNAME=`basename $0`
+# Packages required on build host and requirements for built packages
 DEBIAN_PKGS="gcc git libcurl3 libcurl4-openssl-dev libpcap0.8 libpcap-dev \
-    libssl1.0.2 libssl-dev make python python-pip ruby \
-    ruby-ffi zlib1g zlib1g-dev libbz2-1.0 libbz2-dev"
-DEBIAN_REQS="-d bzip2 -d libcurl3 -d libpcap0.8 -d libssl1.0.2"
+    libssl1.0.2 libssl-dev make python python-pip ruby ruby-ffi"
+DEBIAN_REQS="-d libcurl3 -d libpcap0.8 -d libssl1.0.2 -d logrotate"
 UBUNTU_PKGS="gcc git libcurl3 libcurl4-openssl-dev libpcap0.8 libpcap-dev \
-    libssl1.0.0 libssl-dev make python python-pip ruby \
-    ruby-ffi zlib1g zlib1g-dev"
-UBUNTU_REQS="-d bzip2 -d libcurl3 -d libpcap0.8 -d libssl1.0.0"
+    libssl1.0.0 libssl-dev make python python-pip ruby ruby-ffi"
+UBUNTU_REQS="-d libcurl3 -d libpcap0.8 -d libssl1.0.0 -d logrotate"
 MAC_PKGS="gcc gem git make python ruby"
 RPM_PKGS="gcc git libcurl libcurl-devel libpcap libpcap-devel make openssl \
-    openssl-devel python python2-pip ruby rubygems zlib zlib-devel \
-    bzip2-libs bzip2-devel"
+    openssl-devel python python2-pip ruby rubygems"
+RPM_REQS="-d libcurl -d libpcap -d logrotate -d openssl -d openssl-libs"
 ARCH=`uname -m`
 
 echo
@@ -60,7 +59,7 @@ echo
 
 # check command line arguments, ovveride defaults as appropriate
 #
-while getopts "ht:s:r:R:" arg; do
+while getopts "ht:s:r:R:z:" arg; do
     case $arg in
     h)
         usage
@@ -134,6 +133,24 @@ fi
 if [ $COMPRESSION != "none" -a $COMPRESSION != "gzip" -a $COMPRESSION != "bzip2" ]; then
     echo "-z compression-type must be none, gzip or bzip2"
     exit 1  
+fi
+
+# Compression-specific packages and requirements
+#
+if [ $COMPRESSION == "gzip" ]; then
+    DEBIAN_PKGS="$DEBIAN_PKGS zlib1g zlib1g-dev"
+    DEBIAN_REQS="$DEBIAN_REQS -d zlib1g"
+    UBUNTU_PKGS="$UBUNTU_PKGS zlib1g zlib1g-dev"
+    UBUNTU_REQS="$UBUNTU_REQS -d zlib1g"
+    RPM_PKGS="$RPM_PKGS zlib zlib-devel"
+    RPM_REQS="$RPM_REQS -d zlib"
+elif [ $COMPRESSION == "bzip2" ]; then
+    DEBIAN_PKGS="$DEBIAN_PKGS libbz2-1.0 libbz2-dev"
+    DEBIAN_REQS="$DEBIAN_REQS -d bzip2 -d libbz2-1.0"
+    UBUNTU_PKGS="$UBUNTU_PKGS libbz2-1.0 libbz2-dev"
+    UBUNTU_REQS="$UBUNTU_REQS -d bzip2 -d libbz2-1.0"
+    RPM_PKGS="$RPM_PKGS bzip2-libs bzip2-devel"
+    RPM_REQS="$RPM_REQS -d bzip2 -d bzip2-libs"
 fi
 
 # Check for build dependencies
@@ -242,6 +259,7 @@ if [ "$?" != 0 ]; then
 fi
 FPM_LINUX_OPTIONS="-C $BUILDROOT -n $NAME -v $VERSION --iteration $ITERATION \
     --after-install $APP_ROOT/joy/install/postinstall-linux \
+    --before-install $APP_ROOT/joy/install/preinstall-linux \
     --before-remove $APP_ROOT/joy/install/preuninstall-linux \
     --vendor Cisco --config-files /usr/local/etc/joy/ \
     --config-files /usr/local/var/joy \
@@ -267,8 +285,8 @@ if [ "$?" != 0 ]; then
 fi
 # Used for pkg development; grab files not yet checked-in to master
 if [ "$GITREF" != "master" ]; then
-    tar -f $TAR_FILE --delete joy/Makefile joy/install/install-sh joy/install/postinstall-darwin joy/install/preinstall-darwin 2>/dev/null
-    tar -uf $TAR_FILE -C .. joy/Makefile joy/config joy/install/install-sh joy/install/postinstall-darwin joy/install/preinstall-darwin
+    tar -f $TAR_FILE --delete joy/src/joy.c joy/install/preinstall-linux 2>/dev/null
+    tar -uvf $TAR_FILE -C .. joy/src/joy.c joy/install/preinstall-linux
     if [ "$?" != 0 ]; then
         echo Failed to update archive tar
         rmdir $TMPDIR
@@ -335,7 +353,7 @@ if [ "$BUILDTYPE" == "deb" ]; then
         FPM_REQS="$DEBIAN_REQS"
     fi
     fpm -s dir -t deb $FPM_LINUX_OPTIONS $FPM_REQS \
-        -d "python >= 2.7" -d zlib1g -d libbz2-1.0 \
+        -d "python >= 2.7" \
         --deb-no-default-config-files \
         --description 'Joy is a libpcap-based software package for extracting data features from live
 network traffic or packet capture \(pcap\) files, using a flow-oriented model
@@ -352,7 +370,7 @@ threat-relevant data.' \
 elif [ "$BUILDTYPE" == "osxpkg" ]; then
     fpm -s dir -t osxpkg $FPM_MAC_OPTIONS \
         --description 'Joy is a libpcap-based software package for extracting data features from live
-network traffic or packet capture \(pcap\) files, using a flow-oriented model
+network traffic or packet capture (pcap) files, using a flow-oriented model
 similar to that of IPFIX or Netflow, and then representing these data features
 in JSON. It also contains analysis tools that can be applied to these data
 files. Joy can be used to explore data at scale, especially security and
@@ -364,18 +382,25 @@ threat-relevant data.' \
         exit 1
     fi
 elif [ "$BUILDTYPE" == "rpm" ]; then
-    fpm -s dir -t rpm $FPM_LINUX_OPTIONS \
-        -d libcurl -d libpcap -d "kernel >= 3.10" -d openssl \
-        -d openssl-libs -d "python >= 2.7" -d zlib -d bzip2 -d bzip2-libs \
+    if [ "$OSREL" == "centos" -o "$OSREL" == "redhatenterpriseserver" ]; then
+        FPM_REQS="$RPM_REQS"
+    else
+        echo Unable to build rpm on $OSREL
+        exit 1
+    fi
+    fpm -s dir -t rpm $FPM_LINUX_OPTIONS $FPM_REQS \
+        -d "kernel >= 3.10" -d "python >= 2.7" \
         --config-files /etc/systemd/system/joy.service.d/20-accounting.conf \
         --description 'Joy is a libpcap-based software package for extracting data features from live
-network traffic or packet capture \(pcap\) files, using a flow-oriented model
+network traffic or packet capture (pcap) files, using a flow-oriented model
 similar to that of IPFIX or Netflow, and then representing these data features
 in JSON. It also contains analysis tools that can be applied to these data
 files. Joy can be used to explore data at scale, especially security and
 threat-relevant data.' \
         --rpm-dist el7 \
         --rpm-summary "Capture and analyze network flow data for research, forensics and monitoring. (Compression: $COMPRESSION)" \
+        --rpm-attr 775,joy,joy:/usr/local/var/joy \
+        --rpm-attr 775,joy,joy:/usr/local/var/log \
         ./
     if [ "$?" != 0 ]; then
         echo Failed to build RPM

--- a/install/install-sh
+++ b/install/install-sh
@@ -196,7 +196,102 @@ if [ "$sysname" == "Darwin" ]; then
     if [ -z "$PKGBUILD" ]; then
         echo "stopping flow capture daemon (just in case one is already running)"
         launchctl unload /Library/LaunchDaemons/joy.plist
-    fi
+        launchctl unload /Library/LaunchAgents/com.cisco.joy.plist
+
+        # Create or update joy group
+        #
+        OLDGID=$(dscl . -read /Groups/joy PrimaryGroupID 2>/dev/null | awk '{print $2}')
+        if [ -z "$OLDGID" ]; then
+            # joy group does not exist; find next available GID
+            MAXGID=$(dscl . -list /Groups PrimaryGroupID | awk '{print $2}' | sort -ug | tail -1)
+            NEWGID=$((MAXGID+1))
+        else
+            # joy group already exists; re-use existing GID
+            NEWGID=$OLDGID
+        fi
+        echo "creating/updating joy group"
+        dscl . -create /Groups/joy
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not create joy group"
+            exit 1
+        fi
+        dscl . -create /Groups/joy PrimaryGroupID $NEWGID
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not create joy group with GID $NEWGID"
+            exit 1
+        fi
+        dscl . -create /Groups/joy Password \*
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not update joy group Password"
+            exit 1
+        fi
+        dscl . -create /Groups/joy RealName "joy group"
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not update joy group RealName"
+            exit 1
+        fi
+        
+        # Create or update joy user
+        #
+        OLDUID=$(dscl . -read /Users/joy UniqueID 2>/dev/null | awk '{print $2}')
+        if [ -z "$OLDUID" ]; then
+            # joy user does not exist; find next available UID
+            MAXUID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -ug | tail -1)
+            NEWUID=$((MAXUID+1))
+        else
+            # joy group already exists; re-use existing UID
+            NEWUID=$OLDUID
+        fi
+        echo "creating/updating joy user"
+        dscl . -create /Users/joy
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not create joy user"
+            exit 1
+        fi
+        dscl . -create /Users/joy Password \*
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user Password"
+            exit 1
+        fi
+        dscl . -create /Users/joy RealUser "Joy User"
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user RealUser"
+            exit 1
+        fi
+        dscl . -create /Users/joy UserShell /usr/bin/false
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user UserShell"
+            exit 1
+        fi
+        dscl . -create /Users/joy UniqueID $NEWUID
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user UniqueID $NEWUID"
+            exit 1
+        fi
+        dscl . -create /Users/joy PrimaryGroupID $NEWGID
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user PrimaryGroupID $NEWGID"
+            exit 1
+        fi
+        dscl . -create /Users/joy NFSHomeDirectory /var/empty
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not set joy user NFSHomeDirectory"
+            exit 1
+        fi
+        dscl . -delete /Users/joy AuthenticationAuthority
+        dscl . -delete /Users/joy PasswordPolicyOptions
+    fi # PKGBUILD
 
     # Create ${PREFIX}/bin directory if it does not currently exist
     create_directory ${PREFIX}/bin
@@ -206,9 +301,17 @@ if [ "$sysname" == "Darwin" ]; then
 
     # Create ${PREFIX}/var/joy directory if it does not currently exist
     create_directory ${PREFIX}/var/joy
+    if [ -z "$PKGBUILD" ]; then
+        chown -R joy:joy ${PREFIX}/var/joy
+        chmod 775 ${PREFIX}/var/joy
+    fi
 
     # Create ${PREFIX}/var/log directory if it does not currently exist
     create_directory ${PREFIX}/var/log
+    if [ -z "$PKGBUILD" ]; then
+        chown -R joy:joy ${PREFIX}/var/log
+        chmod 775 ${PREFIX}/var/log
+    fi
 
     # Create ${PREFIX}/etc directory if it does not currently exist
     create_directory ${PREFIX}/etc
@@ -233,6 +336,23 @@ if [ "$sysname" == "Darwin" ]; then
         exit 1
     fi
 
+    # Install the joy uninstall script
+    if [ -z "$PKGBUILD" ]; then
+        cp ${CWD}/uninstall-sh ${PREFIX}/bin/uninstall-joy
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not copy uninstall-joy to ${PREFIX}/bin"
+            exit 1
+        fi
+    else
+        cp ${CWD}/uninstall-joy-pkg ${PREFIX}/bin
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not copy uninstall-joy-pkg to ${PREFIX}/bin"
+            exit 1
+        fi
+    fi
+
     # Install sleuth script
     cp ${APP_ROOT}/sleuth ${PREFIX}/bin/
     retval=$?
@@ -246,21 +366,21 @@ if [ "$sysname" == "Darwin" ]; then
         echo "Running pip install ${APP_ROOT}/sleuth_pkg/"
         pip install ${APP_ROOT}/sleuth_pkg/
     else
-	cd ${APP_ROOT}/sleuth_pkg
-	SLEUTHVER=`grep version setup.py | awk -F\' '{print $2}'`
-	echo "Running python setup.py bdist --format=gztar"
-	python setup.py bdist --format=gztar
+        cd ${APP_ROOT}/sleuth_pkg
+        SLEUTHVER=`grep version setup.py | awk -F\' '{print $2}'`
+        echo "Running python setup.py bdist --format=gztar"
+        python setup.py bdist --format=gztar
         if [ $retval -ne "0" ]; then
             echo "error: could not run python setup.py for sleuth_pkg"
             exit 1
         fi
-        SLEUTHFILE="${APP_ROOT}/sleuth_pkg/dist/sleuth-${SLEUTHVER}.macosx-${OSXVER}-intel.tar.gz"
-	if [ -f $SLEUTHFILE ]; then
+        SLEUTHFILE="${APP_ROOT}/sleuth_pkg/dist/sleuth-${SLEUTHVER}.macosx-${OSXVER}-${ARCH}.tar.gz"
+        if [ -f $SLEUTHFILE ]; then
             tar -xf $SLEUTHFILE -C $BUILDROOT
-	else
+        else
             echo "Cannot find sleuth tarball $SLEUTHFILE"
             exit 1
-	fi
+        fi
     fi
 
     # Install the configuration file
@@ -327,10 +447,10 @@ if [ "$sysname" == "Darwin" ]; then
 
     # Install the Launchd script for daemon management
     if [ -z "$PKGBUILD" ]; then
-        cp ${CWD}/joy.plist /Library/LaunchDaemons/
+        cp ${CWD}/joy.plist /Library/LaunchAgents/com.cisco.joy.plist
         retval=$?
         if [ $retval -ne "0" ]; then
-            echo "error: could not copy joy.plist to /Library/LaunchDaemons"
+            echo "error: could not copy joy.plist to /Library/LaunchAgents"
             exit 1
         fi
     else
@@ -354,11 +474,12 @@ if [ "$sysname" == "Darwin" ]; then
 
     if [ -z "$PKGBUILD" ]; then
         ls -l ${PREFIX}/bin/joy
+        ls -l ${PREFIX}/bin/uninstall-joy
         ls -l ${PREFIX}/etc/joy/*
         ls -l ${PREFIX}/share/man/man1/joy.1
-        ls -l /Library/LaunchDaemons/joy.plist
+        ls -l /Library/LaunchAgents/com.cisco.joy.plist
         echo "starting flow capture daemon"
-        launchctl load /Library/LaunchDaemons/joy.plist
+        launchctl load /Library/LaunchAgents/com.cisco.joy.plist
     fi
 
     echo "...done"
@@ -384,6 +505,12 @@ elif [ "$sysname" == "Linux" ]; then
         fi
     fi
 
+    # Create joy user and group
+    if [ -z "$PKGBUILD" ]; then
+        getent group joy &>/dev/null || /usr/sbin/groupadd -r joy
+        getent passwd joy &>/dev/null || /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy
+    fi
+
     # Create ${PREFIX}/bin directory if it does not currently exist
     create_directory ${PREFIX}/bin
 
@@ -392,9 +519,17 @@ elif [ "$sysname" == "Linux" ]; then
 
     # Create ${PREFIX}/var/joy directory if it does not currently exist
     create_directory ${PREFIX}/var/joy
+    if [ -z "$PKGBUILD" ]; then
+        chown -R joy.joy ${PREFIX}/var/joy
+        chmod 775 ${PREFIX}/var/joy
+    fi
 
     # Create ${PREFIX}/var/log directory if it does not currently exist
     create_directory ${PREFIX}/var/log
+    if [ -z "$PKGBUILD" ]; then
+        chown -R joy.joy ${PREFIX}/var/log
+        chmod 775 ${PREFIX}/var/joy
+    fi
 
     # Create ${PREFIX}/etc directory if it does not currently exist
     create_directory ${PREFIX}/etc
@@ -435,6 +570,16 @@ elif [ "$sysname" == "Linux" ]; then
         exit 1
     fi
 
+    # Install the joy uninstall script
+    if [ -z "$PKGBUILD" ]; then
+        cp ${CWD}/uninstall-sh ${PREFIX}/bin/uninstall-joy
+        retval=$?
+        if [ $retval -ne "0" ]; then
+            echo "error: could not copy uninstall-joy to ${PREFIX}/bin"
+            exit 1
+        fi
+    fi
+
     # Install sleuth script
     cp ${APP_ROOT}/sleuth ${PREFIX}/bin/
     retval=$?
@@ -453,6 +598,12 @@ elif [ "$sysname" == "Linux" ]; then
 	python setup.py bdist --format=gztar
         if [ $retval -ne "0" ]; then
             echo "error: could not run python setup.py for sleuth_pkg"
+            exit 1
+        fi
+        SLEUTHFILE="${APP_ROOT}/sleuth_pkg/dist/sleuth-${SLEUTHVER}.linux-${ARCH}.tar.gz"
+	if [ -f $SLEUTHFILE ]; then
+            tar -xf $SLEUTHFILE -C $BUILDROOT
+	else
             exit 1
         fi
         SLEUTHFILE="${APP_ROOT}/sleuth_pkg/dist/sleuth-${SLEUTHVER}.linux-${ARCH}.tar.gz"

--- a/install/joy.plist
+++ b/install/joy.plist
@@ -12,5 +12,16 @@
     </array>
     <key>KeepAlive</key>
     <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/joy.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/joy_err.log</string>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>Core</key>
+        <integer>4294967296</integer>
+        <key>ResidentSetSize</key>
+        <integer>4294967296</integer>
+    </dict>
 </dict>
 </plist>

--- a/install/options.cfg
+++ b/install/options.cfg
@@ -193,3 +193,10 @@ verbosity = 0
 # when running in online packet-capture mode.
 # default is joy
 #username = joy
+
+# Show Configuration
+#
+# show_config=1 shows the joy configuration on stderr or in the log file
+# when joy is started.
+# default is 0.
+#show_config = 0

--- a/install/options.cfg
+++ b/install/options.cfg
@@ -188,3 +188,9 @@ aux_resource_path = /usr/local/etc/joy
 # verbosity = 2 -> report on all data of each packet
 verbosity = 0
 
+# Username
+#
+# username sets the user to whom root privileges are dropped
+# when running in online packet-capture mode.
+# default is joy
+#username = joy

--- a/install/options.cfg
+++ b/install/options.cfg
@@ -100,7 +100,7 @@ entropy = 1
 # that originates/terminates on the host to be included in the flow
 # record
 #
-exe = 1
+exe = 0
 
 # Transport Layer Security (TLS) options
 # 
@@ -183,9 +183,14 @@ aux_resource_path = /usr/local/etc/joy
 # Verbosity
 # 
 # verbosity = 0 -> silent
-# verbosity = 1 -> report a summary of each packet
-# verbosity = 2 -> report on all data of each packet
-verbosity = 0
+# verbosity = 1 -> show debug, info, warnings, errors and critical errors
+#                  report all data of each packet
+# verbosity = 2 -> show info, warnings, errors and critical errors
+#                  report a summary of each packet
+# verbosity = 3 -> show warnings, errors and critical errors
+# verbosity = 4 -> show errors and critical errors
+# verbosity = 5 -> show critical errors only
+verbosity = 4
 
 # Username
 #

--- a/install/options.cfg
+++ b/install/options.cfg
@@ -91,10 +91,8 @@ zeros = 0
 # dist=1 causes the byte count distribution to be reported
 dist = 1
 
-
 # entropy=1 causes the entropy to be reported
 entropy = 1
-
 
 # Executable/process information
 #
@@ -103,7 +101,6 @@ entropy = 1
 # record
 #
 exe = 1
-
 
 # Transport Layer Security (TLS) options
 # 
@@ -118,43 +115,41 @@ tls = 1
 # such data to be reported; idp=1460 is a good example
 #idp = 1500
 
-
 # Hyper Text Transfer Protocol (HTTP)
 #
 # http=1 causes HTTP headers and body to be captured
 http = 1
-
 
 # Dynamic Host Configuration Protocol (DHCP)
 #
 # dhcp=1 causes DHCP messages to be captured
 dhcp = 1
 
-
 # Internet Protocol (IP) Identification Field
 #
 # ip_id=1 causes IP ID fields to be captured
 ip_id = 1
-
 
 # TCP Per-Packet Information (PPI)
 #
 # ppi=1 reports TCP header and option information for each packet
 ppi = 1
 
-
 # Domain Name System (DNS)
 #
 # dns=1 causes DNS responses to be reported
 dns = 1
 
+# Secure Shell (SSH)
+#
+# ssh=1 enables SSH traffic to be reported
+ssh = 1
 
 # TCP, UDP, or IDP Payload 
 #
 # payload=1 reports the first 32 bytes of the TCP or UDP payload, or
 # IP payload for non-TCP/UDP protocols
 payload = 1
-
 
 # Traffic Selection
 #
@@ -164,7 +159,6 @@ payload = 1
 # observe all IP traffic.
 bpf = none
 
-
 # Anonymization
 #
 # when anon is set to the name of a file that contains a subnet (in
@@ -172,6 +166,11 @@ bpf = none
 # read in; anon=internal.net anonymizes the RFC 1918 private addresses
 #anon = none 
 #anon = /usr/local/etc/joy/internal.net
+#
+# when useranon is set to the name of a file that contains usernames
+# on each line, that file is read in. HTTP traffic containing
+# those usernames is anonymized.
+#useranon = /usr/local/etc/joy/usernames.txt
 
 # TLS Fingerprinting
 #

--- a/install/postinstall-darwin
+++ b/install/postinstall-darwin
@@ -5,10 +5,15 @@ LAUNCH_AGENT_SRC="/usr/local/etc/joy/joy.plist"
 LAUNCH_AGENT_DEST="/Library/LaunchAgents/com.cisco.joy.plist"
 LOGFILE="/usr/local/var/log/joy-postinstall.log"
 exec >> $LOGFILE 2>&1 
+date
 
 # Uninstall old launch agent
 launchctl unload "$LAUNCH_AGENT_DEST" || true
 rm -f "$LAUNCH_AGENT_DEST" || true
+
+# Change ownership on joy data files
+chown -R joy:joy /usr/local/var/log
+chown -R joy:joy /usr/local/var/joy
 
 # Restore key configuration files
 for file in /usr/local/etc/joy/upload-key /usr/local/etc/joy/upload-key.pub \

--- a/install/postinstall-linux
+++ b/install/postinstall-linux
@@ -21,6 +21,8 @@ if [ "$OSREL" == "CentOS" -o "$OSREL" == "RedHatEnterpriseServer" ]; then
         elif [ -f /etc/init.d/joy -a -f /usr/sbin/chkconfig ]; then
             service joy condrestart >/dev/null 2>&1 || :
         fi
+        # Change owner from root.root to joy.joy
+        chown -R joy.joy /usr/local/var/joy /usr/local/var/log || :
     fi
 elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
     # Initial deb installation
@@ -32,6 +34,7 @@ elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
         elif [ -x /usr/sbin/update-rc.d ]; then
             update-rc.d joy defaults >/dev/null 2>&1 || :
         fi
+        chown joy.joy /usr/local/var/joy /usr/local/var/log || :
     # Upgrade
     else
         if [ -f /usr/lib/systemd/system/joy.service ]; then
@@ -40,6 +43,8 @@ elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
         elif [ -f /etc/init.d/joy ]; then
             service joy condrestart >/dev/null 2>&1 || :
         fi
+        # Change owner from root.root to joy.joy
+        chown -R joy.joy /usr/local/var/joy /usr/local/var/log || :
     fi
 fi
 

--- a/install/preinstall-darwin
+++ b/install/preinstall-darwin
@@ -5,10 +5,7 @@ LAUNCH_AGENT_SRC="/usr/local/etc/joy/joy.plist"
 LAUNCH_AGENT_DEST="/Library/LaunchAgents/com.cisco.joy.plist"
 LOGFILE="/usr/local/var/log/joy-preinstall.log"
 exec >> $LOGFILE 2>&1 
-
-# Uninstall old launch agent
-#launchctl unload "$LAUNCH_AGENT_DEST" || true
-#rm -f "$LAUNCH_AGENT_DEST" || true
+date
 
 # Backup key configuration files
 for file in /usr/local/etc/joy/upload-key /usr/local/etc/joy/upload-key.pub \
@@ -18,5 +15,99 @@ for file in /usr/local/etc/joy/upload-key /usr/local/etc/joy/upload-key.pub \
     		cp -a $file ${file}.previous-install
 	fi
 done
+
+# Create or update joy group
+#
+OLDGID=$(dscl . -read /Groups/joy PrimaryGroupID 2>/dev/null | awk '{print $2}')
+if [ -z "$OLDGID" ]; then
+    # joy group does not exist; find next available GID
+    MAXGID=$(dscl . -list /Groups PrimaryGroupID | awk '{print $2}' | sort -ug | tail -1)
+    NEWGID=$((MAXGID+1))
+else
+    # joy group already exists; re-use existing GID
+    NEWGID=$OLDGID
+fi
+    echo "creating/updating joy group"
+    dscl . -create /Groups/joy
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not create joy group"
+        exit 1
+    fi
+    dscl . -create /Groups/joy PrimaryGroupID $NEWGID
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not create joy group with GID $NEWGID"
+        exit 1
+    fi
+    dscl . -create /Groups/joy Password \*
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not update joy group Password"
+        exit 1
+    fi
+    dscl . -create /Groups/joy RealName "joy group"
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not update joy group RealName"
+        exit 1
+    fi
+        
+# Create or update joy user
+#
+OLDUID=$(dscl . -read /Users/joy UniqueID 2>/dev/null | awk '{print $2}')
+if [ -z "$OLDUID" ]; then
+    # joy user does not exist; find next available UID
+    MAXUID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -ug | tail -1)
+    NEWUID=$((MAXUID+1))
+else
+    # joy group already exists; re-use existing UID
+    NEWUID=$OLDUID
+fi
+    echo "creating/updating joy user"
+    dscl . -create /Users/joy 
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not create joy user"
+        exit 1
+    fi
+    dscl . -create /Users/joy Password \*
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user Password"
+        exit 1
+    fi
+    dscl . -create /Users/joy RealUser "Joy User"
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user RealUser"
+        exit 1
+    fi
+    dscl . -create /Users/joy UserShell /usr/bin/false
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user UserShell"
+        exit 1
+    fi
+    dscl . -create /Users/joy UniqueID $NEWUID
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user UniqueID $NEWUID"
+        exit 1
+    fi
+    dscl . -create /Users/joy PrimaryGroupID $NEWGID
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user PrimaryGroupID $NEWGID"
+        exit 1
+    fi
+    dscl . -create /Users/joy NFSHomeDirectory /var/empty
+    retval=$?
+    if [ $retval -ne "0" ]; then
+        echo "error: could not set joy user NFSHomeDirectory"
+        exit 1
+    fi
+    dscl . -delete /Users/joy AuthenticationAuthority
+    dscl . -delete /Users/joy PasswordPolicyOptions
 
 exit 0

--- a/install/preinstall-linux
+++ b/install/preinstall-linux
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Determine OS release
+OSREL=`lsb_release -is 2>/dev/null`
+
+# On first install, add joy user and group
+#
+if [ "$OSREL" == "CentOS" -o "$OSREL" == "RedHatEnterpriseServer" ]; then
+    # RPM install, not upgrade
+    if [ $1 -eq 1 ] ; then
+        /usr/sbin/groupadd -r joy 2> /dev/null
+        /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
+    fi
+elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
+    # deb install, not upgrade
+    if [ -z $2 ]; then
+        /usr/sbin/groupadd -r joy 2> /dev/null
+        /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
+    fi
+fi

--- a/install/preinstall-linux
+++ b/install/preinstall-linux
@@ -6,9 +6,9 @@ OSREL=`lsb_release -is 2>/dev/null`
 # On first install, add joy user and group
 #
 if [ "$OSREL" == "CentOS" -o "$OSREL" == "RedHatEnterpriseServer" ]; then
-    /usr/sbin/groupadd -r joy 2> /dev/null
-    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
+    /usr/sbin/groupadd -r joy 2> /dev/null || :
+    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null || :
 elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
-    /usr/sbin/groupadd -r joy 2> /dev/null
-    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
+    /usr/sbin/groupadd -r joy 2> /dev/null || :
+    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null || :
 fi

--- a/install/preinstall-linux
+++ b/install/preinstall-linux
@@ -6,15 +6,9 @@ OSREL=`lsb_release -is 2>/dev/null`
 # On first install, add joy user and group
 #
 if [ "$OSREL" == "CentOS" -o "$OSREL" == "RedHatEnterpriseServer" ]; then
-    # RPM install, not upgrade
-    if [ $1 -eq 1 ] ; then
-        /usr/sbin/groupadd -r joy 2> /dev/null
-        /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
-    fi
+    /usr/sbin/groupadd -r joy 2> /dev/null
+    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
 elif [ "$OSREL" == "Ubuntu" -o "$OSREL" == "Debian" ]; then
-    # deb install, not upgrade
-    if [ -z $2 ]; then
-        /usr/sbin/groupadd -r joy 2> /dev/null
-        /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
-    fi
+    /usr/sbin/groupadd -r joy 2> /dev/null
+    /usr/sbin/useradd -g joy -s /sbin/nologin -M -r -d / joy 2> /dev/null
 fi

--- a/install/uninstall-joy-pkg
+++ b/install/uninstall-joy-pkg
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# uninstall-joy-pkg
+#
+# uninstaller for joy MacOS X package
+
+PKGNAME=com.cisco.joy
+
+echo
+echo UNINSTALL-JOY-PKG
+echo --------------------
+echo
+
+if ((UID!=0)); then
+    echo "You must run as root"
+    exit 1
+fi
+
+delete_file () {
+    if [ -f $1 ]; then
+        rm $1
+        retval=$?
+        if [ $retval != "0" ]; then
+            echo "error: could not delete file $1"
+        else
+            echo "deleted file $1"
+        fi
+    fi
+}
+
+delete_directory () {
+    if [ -d $1 ]; then
+        rm -rf $1
+        retval=$?
+        if [ $retval != "0" ]; then
+            echo "error: could not delete directory $1"
+        else
+            echo "deleted directory $1"
+        fi
+    fi
+}
+
+sysname=`uname -s`
+
+if [ "$sysname" == "Darwin" ]; then
+    ##
+    # Darwin operating system detected
+    ##
+    echo "System $sysname (Mac OS X) uninstalling package ${PKGNAME} ..."
+
+    pkgutil --pkg-info ${PKGNAME} &>/dev/null
+    if [ "$?" == 0 ]; then
+        # Stop the daemon
+        launchctl unload /Library/LaunchAgents/${PKGNAME}.plist
+        delete_file /Library/LaunchAgents/${PKGNAME}.plist
+
+        # Delete the application files
+        cd /
+        pkgutil --only-files --files ${PKGNAME} | tr '\n' '\0' | xargs -n 1 -0 rm
+        pkgutil --forget ${PKGNAME}
+
+        echo "... removed ${PKGNAME}"
+    else
+        echo "... unable to find ${PKGNAME}"
+        exit 1
+    fi
+else
+    echo "error: unknown system ($sysname)"
+    exit 1
+fi

--- a/install/uninstall-sh
+++ b/install/uninstall-sh
@@ -42,10 +42,20 @@ if [ "$sysname" == "Darwin" ]; then
     ##
     # Darwin operating system detected
     ##
+
+    pkgutil --pkg-info com.cisco.joy 2>/dev/null
+    if [ $? == 0 -o -f /usr/local/bin/uninstall-joy-pkg ]; then
+        echo
+        echo "You appear to have installed the Joy binary package."
+        echo "Please run the /usr/local/bin/uninstall-joy-pkg script."
+        echo
+        exit 1
+    fi
     echo "System $sysname (Mac OS X) uninstalling ..."
 
     # Stop the daemon
     launchctl unload /Library/LaunchDaemons/joy.plist
+    launchctl unload /Library/LaunchAgents/com.cisco.joy.plist
 
     # Delete the application files
     delete_file /usr/local/bin/joy
@@ -55,10 +65,14 @@ if [ "$sysname" == "Darwin" ]; then
     delete_directory /usr/local/etc/joy
 
     delete_file /Library/LaunchDaemons/joy.plist
+    delete_file /Library/LaunchAgents/com.cisco.joy.plist
 
     delete_file /usr/local/share/man/man1/joy.1
 
+    # Uninstall the sleuth python module
+    pip uninstall -y sleuth
     echo "... done"
+
     echo
 elif [ "$sysname" == "Linux" ]; then
     ##

--- a/src/config.c
+++ b/src/config.c
@@ -165,6 +165,9 @@ static int config_parse_command (struct configuration *config,
     } else if (match(command, "outdir")) {
         parse_check(parse_string(&config->outputdir, arg, num));
 
+    } else if (match(command, "username")) {
+        parse_check(parse_string(&config->username, arg, num));
+
     } else if (match(command, "log")) {
         parse_check(parse_string(&config->logfile, arg, num));
 
@@ -293,6 +296,7 @@ void config_set_defaults (struct configuration *config) {
     config->type = 1;
     config->verbosity = 4;
     config->show_config = 0;
+    config->username = "joy";    /*!< default username */
 }
 
 /**
@@ -454,6 +458,7 @@ void config_print (FILE *f, const struct configuration *c) {
     fprintf(f, "promisc = %u\n", c->promisc);
     fprintf(f, "output = %s\n", val(c->filename));
     fprintf(f, "outputdir = %s\n", val(c->outputdir));
+    fprintf(f, "username = %s\n", val(c->username));
     fprintf(f, "count = %u\n", c->max_records); 
     fprintf(f, "upload = %s\n", val(c->upload_servername));
     fprintf(f, "keyfile = %s\n", val(c->upload_key));
@@ -499,6 +504,7 @@ void config_print_json (zfile f, const struct configuration *c) {
     zprintf(f, "\"promisc\":%u,", c->promisc);
     zprintf(f, "\"output\":\"%s\",", val(c->filename));
     zprintf(f, "\"outputdir\":\"%s\",", val(c->outputdir));
+    zprintf(f, "\"username\":\"%s\",", val(c->username));
     zprintf(f, "\"info\":\"%s\",", val(c->logfile));
     zprintf(f, "\"count\":%u,", c->max_records); 
     zprintf(f, "\"upload\":\"%s\",", val(c->upload_servername));

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -89,6 +89,7 @@ struct configuration {
     char *intface;
     char *filename;              /*!< output file, if not NULL */
     char *outputdir;             /*!< directory to write output files */
+    char *username;              /*!< username to become when dropping root */
     char *logfile; 
     char *anon_addrs_file;
     char *anon_http_file;


### PR DESCRIPTION
Added configuration option username (joy is default).  When joy starts in online mode, it opens the network interface as root and immediately drops to joy user for writing JSON and log files.
Package script has also been improved to minimize requirements based on compression option; if gzip compression is used, only require zlib.  If bzip2 compression is used, only require bzip2.
Also updated the default config file to add documentation on various configuration items (ssh, useranon, username, and show_config).