### PR TITLE
Fixed case in http.c producing invalid JSON.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -559,12 +559,15 @@ static void http_print_header(zfile f, char *header, unsigned length) {
 
     token1 = token2 = NULL; /* initialize just to avoid compiler warnings */
 
+    /* Start req/resp array */
+    zprintf(f, "[");
+
     if (length < 4) {
+        /* End req/resp array */
+        zprintf(f, "]");
         return;
     }
 
-    /* Start req/resp array */
-    zprintf(f, "[");
 
     /*
      * parse start-line, and print as request/status as appropriate


### PR DESCRIPTION
This fixes a bug in http_print_header.  Previously if it hit the `length < 4` check it would produce an output similar to this:

```json
"http": [ {
    "out":
} ]
```
Now it will print this:
```json
"http":[ {
    "out": []
} ]
```
The original case is not valid JSON and will trip up JSON parsers such as python's json.loads().