### PR TITLE
updated the procwatch code to better handle exe=1 option

### DIFF
--- a/src/include/procwatch.h
+++ b/src/include/procwatch.h
@@ -50,7 +50,7 @@
 #define ALL_PROC_SOCKETS 1
 #define ACTIVE_PROC_SOCKETS_ONLY 0
 
-#define HOST_PROC_FLOW_TABLE_LEN 512
+#define HOST_PROC_FLOW_TABLE_LEN 1024
 
 struct host_flow {
 	struct flow_key key;

--- a/src/include/procwatch.h
+++ b/src/include/procwatch.h
@@ -56,6 +56,7 @@ struct host_flow {
 	struct flow_key key;
 	unsigned long pid;
 	unsigned long parent_pid;
+	unsigned long inode;
 	unsigned int threads;
 	char *exe_name;
 	char *full_path;

--- a/src/include/procwatch.h
+++ b/src/include/procwatch.h
@@ -50,7 +50,7 @@
 #define ALL_PROC_SOCKETS 1
 #define ACTIVE_PROC_SOCKETS_ONLY 0
 
-#define HOST_PROC_FLOW_TABLE_LEN 128
+#define HOST_PROC_FLOW_TABLE_LEN 512
 
 struct host_flow {
 	struct flow_key key;

--- a/src/joy.c
+++ b/src/joy.c
@@ -1513,7 +1513,6 @@ int main (int argc, char **argv) {
             if (config.report_exe) {
                   /*
                    * periodically obtain host/process flow data
-                   * PP: Not implemented for WIN32. Need to handle
                    */ 
                   if (get_host_flow_data() != 0) {
                       joy_log_warn("Could not obtain host/process flow data\n");


### PR DESCRIPTION
updated the procwatch code to better handle exe=1 option. CPU usage was extremely high in prior versions. I modified the processing loop to only update the process data every 30 seconds. Additionally, on the MAC and Windows platforms, I optimized getting that data when the table is refreshed. On the linux platform, I implemented the gathering of the process data similar to the original design (read /proc/net/tcp) and then read the active PIDs. This still takes a decent amount of time on the linux platform, but the CPU only spikes and settles down fairly quickly.