### PR TITLE
add the ability to pull the process uptime on linux, Mac OS X and windows

### DIFF
--- a/src/include/p2f.h
+++ b/src/include/p2f.h
@@ -131,7 +131,7 @@ struct flow_record {
 	char *full_path;                      /*!< executable path associated with flow    */
 	char *file_version;                   /*!< executable version associated with flow    */
 	char *file_hash;                      /*!< executable file hash associated with flow    */
-	char *proc_uptime;                    /*!< executable uptime associated with flow    */
+	unsigned long uptime_seconds;         /*!< executable uptime associated with flow    */
     unsigned char exp_type;
     unsigned char first_switched_found;   /*!< hack to make sure we only correct once */
   

--- a/src/include/p2f.h
+++ b/src/include/p2f.h
@@ -131,6 +131,7 @@ struct flow_record {
 	char *full_path;                      /*!< executable path associated with flow    */
 	char *file_version;                   /*!< executable version associated with flow    */
 	char *file_hash;                      /*!< executable file hash associated with flow    */
+	char *proc_uptime;                    /*!< executable uptime associated with flow    */
     unsigned char exp_type;
     unsigned char first_switched_found;   /*!< hack to make sure we only correct once */
   

--- a/src/include/procwatch.h
+++ b/src/include/procwatch.h
@@ -61,6 +61,7 @@ struct host_flow {
 	char *full_path;
 	char *file_version;
 	char *hash;
+	char *proc_uptime;
 };
 
 /*

--- a/src/include/procwatch.h
+++ b/src/include/procwatch.h
@@ -56,12 +56,12 @@ struct host_flow {
 	struct flow_key key;
 	unsigned long pid;
 	unsigned long parent_pid;
+	unsigned long uptime_seconds;
 	unsigned int threads;
 	char *exe_name;
 	char *full_path;
 	char *file_version;
 	char *hash;
-	char *proc_uptime;
 };
 
 /*

--- a/src/p2f.c
+++ b/src/p2f.c
@@ -834,10 +834,6 @@ static void flow_record_delete (struct flow_record *r) {
 		free(r->file_hash);
 	}
 
-	if (r->proc_uptime) {
-		free(r->proc_uptime);
-	}
-
     delete_all_features(feature_list);
 
     /*
@@ -879,10 +875,7 @@ int flow_key_set_process_info(const struct flow_key *key, const struct host_flow
                     if (data->hash)
 			r->file_hash = strdup(data->hash);
 		}
-		if (r->proc_uptime == NULL) {
-                    if (data->proc_uptime)
-			r->proc_uptime = strdup(data->proc_uptime);
-		}
+		r->uptime_seconds = data->uptime_seconds;
 		return ok;
 	}
 	return failure;
@@ -1068,11 +1061,11 @@ static void print_executable_json (zfile f, const struct flow_record *rec) {
                 comma = 1;
             }
         }
-        if (rec->proc_uptime) {
+        if (rec->uptime_seconds > 0) {
             if (comma) {
-                zprintf(output, ",\"uptime\":\"%s\"", rec->proc_uptime);
+                zprintf(output, ",\"uptime\":%lu", rec->uptime_seconds);
             } else {
-                zprintf(output, "\"uptime\":\"%s\"", rec->proc_uptime);
+                zprintf(output, "\"uptime\":%lu", rec->uptime_seconds);
                 comma = 1;
             }
         }

--- a/src/p2f.c
+++ b/src/p2f.c
@@ -834,6 +834,10 @@ static void flow_record_delete (struct flow_record *r) {
 		free(r->file_hash);
 	}
 
+	if (r->proc_uptime) {
+		free(r->proc_uptime);
+	}
+
     delete_all_features(feature_list);
 
     /*
@@ -874,6 +878,10 @@ int flow_key_set_process_info(const struct flow_key *key, const struct host_flow
 		if (r->file_hash == NULL) {
                     if (data->hash)
 			r->file_hash = strdup(data->hash);
+		}
+		if (r->proc_uptime == NULL) {
+                    if (data->proc_uptime)
+			r->proc_uptime = strdup(data->proc_uptime);
 		}
 		return ok;
 	}
@@ -1057,6 +1065,14 @@ static void print_executable_json (zfile f, const struct flow_record *rec) {
                 zprintf(output, ",\"hash\":\"%s\"", rec->file_hash);
             } else {
                 zprintf(output, "\"hash\":\"%s\"", rec->file_hash);
+                comma = 1;
+            }
+        }
+        if (rec->proc_uptime) {
+            if (comma) {
+                zprintf(output, ",\"uptime\":\"%s\"", rec->proc_uptime);
+            } else {
+                zprintf(output, "\"uptime\":\"%s\"", rec->proc_uptime);
                 comma = 1;
             }
         }

--- a/src/procwatch.c
+++ b/src/procwatch.c
@@ -500,7 +500,7 @@ static unsigned long get_process_uptime (unsigned long pid) {
             int got_mins = 0;
             int got_secs = 0;
 
-            /* format of elasped times is day-hr:min:sec 
+            /* format of elasped times is day-hr:min:sec
              * not all fields are always present, so process from
              * the back of the string.
              */

--- a/src/procwatch.c
+++ b/src/procwatch.c
@@ -357,7 +357,7 @@ void get_process_info(HANDLE hProcessSnap, unsigned long pid, struct host_flow *
 					SystemTimeToFileTime(&currentTime, &stopTime);
 					elapsedTime.li = stopTime.li - createTime.li;
 					FileTimeToSystemTime(&elapsedTime.ft, &upTime);
-					seconds = (upTime.wHour * 3600) + (upTime.wMinute * 60) + upTime.wSecond;
+					seconds = (uTime.wDay * 86400) + (upTime.wHour * 3600) + (upTime.wMinute * 60) + upTime.wSecond;
 					record->uptime_seconds = seconds;
 				}
 				CloseHandle(hProcess);

--- a/src/procwatch.c
+++ b/src/procwatch.c
@@ -593,9 +593,6 @@ static void get_pid_path_hash (struct host_flow *hf) {
     }
 }
 
-static unsigned long get_process_uptime (unsigned long pid) {
-}
-
 static void process_pid_string (char *string) {
     char *s = string;
 
@@ -674,7 +671,7 @@ static void host_flow_table_add_tcp (unsigned int all_sockets) {
                 hf->exe_name = malloc(strlen(fr.command)+1);
                 strcpy(hf->exe_name,fr.command);
             }
-            hf->proc_uptime = get_process_uptime(hf->pid);
+            hf->uptime_seconds = get_process_uptime(hf->pid);
             get_pid_path_hash(hf);
         }
 


### PR DESCRIPTION
add the ability to pull the process uptime on linux, Mac OS X and windows. This new data field is output in the "exe" object when the exe=1 option is issued on the command line and we can find the information about the particular process associated with the flow data. The uptime is reported in the following fashion:
  "uptime":\<long\>