### PR TITLE
remove extra comma when qdcount is <= 0 in DNS

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -656,9 +656,9 @@ static void dns_print_packet (char *dns_name, unsigned int pkt_len, zfile output
             zprintf_debug("question err=%u; len=%u\"]}]", err, len);
             return;
         }
-        zprintf(output, "\"%cn\":\"%s\"", qr, name + 1);
+        zprintf(output, "\"%cn\":\"%s\",", qr, name + 1);
     }
-    zprintf(output, ",\"rc\":%u,\"rr\":[", rh->rcode);
+    zprintf(output, "\"rc\":%u,\"rr\":[", rh->rcode);
 
     ancount = ntohs(rh->ancount); 
     comma = 0;


### PR DESCRIPTION
Small change to fix issues with:
"dns":[{,"rc":11,"rr":[{"malformed":36,"DEBUG": "rr name ancount=4558; err=5; len=36; data=0xffffffad26ffffffc973"}]}],