### PR TITLE
update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 /*
  *	
- * Copyright (c) 2016 Cisco Systems, Inc.
- * All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. and/or its affiliates
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
The "All rights reserved." should be removed because this repo is being licensed under the terms of the BSD license, not reserving all rights.