### PR TITLE
bug in calculating the BD

### DIFF
--- a/src/p2f.c
+++ b/src/p2f.c
@@ -830,6 +830,7 @@ void flow_record_update_timeouts (unsigned int inact, unsigned int act) {
 void flow_record_update_byte_count (flow_record_t *f, const void *x, unsigned int len) {
     const unsigned char *data = x;
     unsigned int i;
+    unsigned int current_count = 0;
 
     /*
      * implementation note: The spec says that 4000 octets is enough of a
@@ -838,10 +839,17 @@ void flow_record_update_byte_count (flow_record_t *f, const void *x, unsigned in
      * the 4000th octet has been seen for a flow.
      */
 
+    /* octet count was already incremented before processing this payload */
+    current_count = f->ob - len;
+
     if (glb_config->byte_distribution || glb_config->report_entropy) {
-        if (f->ob < ETTA_MIN_OCTETS) {
+        if (current_count < ETTA_MIN_OCTETS) {
             for (i=0; i<len; i++) {
                 f->byte_count[data[i]]++;
+                current_count++;
+                if (current_count >= ETTA_MIN_OCTETS) {
+                   break;
+                }
             }
         }
     }


### PR DESCRIPTION
bug in calculating the byte distribution counts. If the current packet pushed the count over the 4k number, the 4k-old count bytes were not included in the distribution.