### PR TITLE
Default to not require safecstubs library for libjoy.a

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,6 +1,8 @@
 
 
 lib_LTLIBRARIES = libjoy.la
+
+if BUILD_WITH_SAFEC
 libjoy_la_SOURCES = \
 	../src/joy_api.c \
 	../src/p2f.c \
@@ -78,16 +80,89 @@ libjoy_la_SOURCES = \
 		../src/include/wht.h \
 		../src/include/fp.h \
 		../src/include/extractor.h
-
-if BUILD_WITH_SAFEC
-    libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lciscosafec
 else
-    libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lstubsafec
+libjoy_la_SOURCES = \
+	../src/joy_api.c \
+	../src/p2f.c \
+	../src/osdetect.c \
+	../src/anon.c \
+	../src/pkt_proc.c \
+	../src/nfv9.c \
+	../src/tls.c \
+	../src/classify.c \
+	../src/radix_trie.c \
+	../src/hdr_dsc.c \
+	../src/procwatch.c \
+	../src/addr_attr.c \
+	../src/addr.c \
+	../src/wht.c \
+	../src/http.c \
+	../src/str_match.c \
+	../src/acsm.c \
+	../src/dns.c \
+	../src/example.c \
+	../src/ipfix.c \
+	../src/ssh.c \
+	../src/ike.c \
+	../src/salt.c \
+	../src/parson.c \
+	../src/fingerprint.c \
+	../src/ppi.c \
+	../src/utils.c \
+	../src/dhcp.c \
+	../src/payload.c \
+	../src/config.c \
+	../src/proto_identify.c \
+	../src/fp.c \
+	../src/extractor.c \
+	../safe_c_stub/src/safe_str_stub.c \
+	../safe_c_stub/src/safe_mem_stub.c \
+	../src/include/acsm.h \
+		../src/include/addr_attr.h \
+		../src/include/addr.h \
+		../src/include/anon.h \
+		../src/include/classify.h \
+		../src/include/config.h \
+		../src/include/dhcp.h \
+		../src/include/dns.h \
+		../src/include/err.h \
+		../src/include/example.h \
+		../src/include/feature.h \
+		../src/include/fingerprint.h \
+		../src/include/hdr_dsc.h \
+		../src/include/http.h \
+		../src/include/ike.h \
+		../src/include/ipfix.h \
+		../src/include/joy_api.h \
+		../src/include/joy_api_private.h \
+		../src/include/map.h \
+		../src/include/modules.h \
+		../src/include/nfv9.h \
+		../src/include/osdetect.h \
+		../src/include/output.h \
+		../src/include/p2f.h \
+		../src/include/parson.h \
+		../src/include/payload.h \
+		../src/include/pkt.h \
+		../src/include/pkt_proc.h \
+		../src/include/ppi.h \
+		../src/include/procwatch.h \
+		../src/include/proto_identify.h \
+		../src/include/radix_trie.h \
+		../src/include/salt.h \
+		../src/include/ssh.h \
+		../src/include/str_match.h \
+		../src/include/tls.h \
+		../src/include/updater.h \
+		../src/include/utils.h \
+		../src/include/fp.h \
+		../src/include/extractor.h \
+		../src/include/wht.h \
+		../src/include/fp.h \
+		../src/include/extractor.h
 endif
+
 libjoy_la_CFLAGS = -I ../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include -I $(SAFEC_DIR)/include/safec
-
-libjoy_la_LDFLAGS = -version-info $(JOY_LIBRARY_VERSION) $(SSL_LDFLAGS) -lcrypto
-
 
 library_includedir=$(includedir)/joy
 library_include_HEADERS= \
@@ -135,4 +210,11 @@ library_include_HEADERS= \
 		../src/include/fp.h \
 		../src/include/extractor.h
 
+
+if BUILD_WITH_SAFEC
+    libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lciscosafec
+else
+    libjoy_la_LIBADD = $(SSL_LDFLAGS) -lcrypto
+endif
+libjoy_la_LDFLAGS = -version-info $(JOY_LIBRARY_VERSION) $(SSL_LDFLAGS) -lcrypto 
 

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -73,25 +73,112 @@ am__base_list = \
 am__installdirs = "$(DESTDIR)$(libdir)" \
 	"$(DESTDIR)$(library_includedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
-libjoy_la_DEPENDENCIES =
+am__DEPENDENCIES_1 =
+@BUILD_WITH_SAFEC_FALSE@libjoy_la_DEPENDENCIES =  \
+@BUILD_WITH_SAFEC_FALSE@	$(am__DEPENDENCIES_1)
+am__libjoy_la_SOURCES_DIST = ../src/joy_api.c ../src/p2f.c \
+	../src/osdetect.c ../src/anon.c ../src/pkt_proc.c \
+	../src/nfv9.c ../src/tls.c ../src/classify.c \
+	../src/radix_trie.c ../src/hdr_dsc.c ../src/procwatch.c \
+	../src/addr_attr.c ../src/addr.c ../src/wht.c ../src/http.c \
+	../src/str_match.c ../src/acsm.c ../src/dns.c ../src/example.c \
+	../src/ipfix.c ../src/ssh.c ../src/ike.c ../src/salt.c \
+	../src/parson.c ../src/fingerprint.c ../src/ppi.c \
+	../src/utils.c ../src/dhcp.c ../src/payload.c ../src/config.c \
+	../src/proto_identify.c ../src/fp.c ../src/extractor.c \
+	../safe_c_stub/src/safe_str_stub.c \
+	../safe_c_stub/src/safe_mem_stub.c ../src/include/acsm.h \
+	../src/include/addr_attr.h ../src/include/addr.h \
+	../src/include/anon.h ../src/include/classify.h \
+	../src/include/config.h ../src/include/dhcp.h \
+	../src/include/dns.h ../src/include/err.h \
+	../src/include/example.h ../src/include/feature.h \
+	../src/include/fingerprint.h ../src/include/hdr_dsc.h \
+	../src/include/http.h ../src/include/ike.h \
+	../src/include/ipfix.h ../src/include/joy_api.h \
+	../src/include/joy_api_private.h ../src/include/map.h \
+	../src/include/modules.h ../src/include/nfv9.h \
+	../src/include/osdetect.h ../src/include/output.h \
+	../src/include/p2f.h ../src/include/parson.h \
+	../src/include/payload.h ../src/include/pkt.h \
+	../src/include/pkt_proc.h ../src/include/ppi.h \
+	../src/include/procwatch.h ../src/include/proto_identify.h \
+	../src/include/radix_trie.h ../src/include/salt.h \
+	../src/include/ssh.h ../src/include/str_match.h \
+	../src/include/tls.h ../src/include/updater.h \
+	../src/include/utils.h ../src/include/fp.h \
+	../src/include/extractor.h ../src/include/wht.h
 am__dirstamp = $(am__leading_dot)dirstamp
-am_libjoy_la_OBJECTS = ../src/libjoy_la-joy_api.lo \
-	../src/libjoy_la-p2f.lo ../src/libjoy_la-osdetect.lo \
-	../src/libjoy_la-anon.lo ../src/libjoy_la-pkt_proc.lo \
-	../src/libjoy_la-nfv9.lo ../src/libjoy_la-tls.lo \
-	../src/libjoy_la-classify.lo ../src/libjoy_la-radix_trie.lo \
-	../src/libjoy_la-hdr_dsc.lo ../src/libjoy_la-procwatch.lo \
-	../src/libjoy_la-addr_attr.lo ../src/libjoy_la-addr.lo \
-	../src/libjoy_la-wht.lo ../src/libjoy_la-http.lo \
-	../src/libjoy_la-str_match.lo ../src/libjoy_la-acsm.lo \
-	../src/libjoy_la-dns.lo ../src/libjoy_la-example.lo \
-	../src/libjoy_la-ipfix.lo ../src/libjoy_la-ssh.lo \
-	../src/libjoy_la-ike.lo ../src/libjoy_la-salt.lo \
-	../src/libjoy_la-parson.lo ../src/libjoy_la-fingerprint.lo \
-	../src/libjoy_la-ppi.lo ../src/libjoy_la-utils.lo \
-	../src/libjoy_la-dhcp.lo ../src/libjoy_la-payload.lo \
-	../src/libjoy_la-config.lo ../src/libjoy_la-proto_identify.lo \
-	../src/libjoy_la-fp.lo ../src/libjoy_la-extractor.lo
+@BUILD_WITH_SAFEC_FALSE@am_libjoy_la_OBJECTS =  \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-joy_api.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-p2f.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-osdetect.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-anon.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-pkt_proc.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-nfv9.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-tls.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-classify.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-radix_trie.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-hdr_dsc.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-procwatch.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-addr_attr.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-addr.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-wht.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-http.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-str_match.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-acsm.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-dns.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-example.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-ipfix.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-ssh.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-ike.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-salt.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-parson.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-fingerprint.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-ppi.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-utils.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-dhcp.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-payload.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-config.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-proto_identify.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-fp.lo \
+@BUILD_WITH_SAFEC_FALSE@	../src/libjoy_la-extractor.lo \
+@BUILD_WITH_SAFEC_FALSE@	../safe_c_stub/src/libjoy_la-safe_str_stub.lo \
+@BUILD_WITH_SAFEC_FALSE@	../safe_c_stub/src/libjoy_la-safe_mem_stub.lo
+@BUILD_WITH_SAFEC_TRUE@am_libjoy_la_OBJECTS =  \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-joy_api.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-p2f.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-osdetect.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-anon.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-pkt_proc.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-nfv9.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-tls.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-classify.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-radix_trie.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-hdr_dsc.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-procwatch.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-addr_attr.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-addr.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-wht.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-http.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-str_match.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-acsm.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-dns.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-example.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-ipfix.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-ssh.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-ike.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-salt.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-parson.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-fingerprint.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-ppi.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-utils.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-dhcp.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-payload.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-config.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-proto_identify.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-fp.lo \
+@BUILD_WITH_SAFEC_TRUE@	../src/libjoy_la-extractor.lo
 libjoy_la_OBJECTS = $(am_libjoy_la_OBJECTS)
 libjoy_la_LINK = $(LIBTOOL) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libjoy_la_CFLAGS) \
@@ -110,7 +197,7 @@ LINK = $(LIBTOOL) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) \
 	--mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 SOURCES = $(libjoy_la_SOURCES)
-DIST_SOURCES = $(libjoy_la_SOURCES)
+DIST_SOURCES = $(am__libjoy_la_SOURCES_DIST)
 HEADERS = $(library_include_HEADERS)
 ETAGS = etags
 CTAGS = ctags
@@ -236,88 +323,165 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 lib_LTLIBRARIES = libjoy.la
-libjoy_la_SOURCES = \
-	../src/joy_api.c \
-	../src/p2f.c \
-	../src/osdetect.c \
-	../src/anon.c \
-	../src/pkt_proc.c \
-	../src/nfv9.c \
-	../src/tls.c \
-	../src/classify.c \
-	../src/radix_trie.c \
-	../src/hdr_dsc.c \
-	../src/procwatch.c \
-	../src/addr_attr.c \
-	../src/addr.c \
-	../src/wht.c \
-	../src/http.c \
-	../src/str_match.c \
-	../src/acsm.c \
-	../src/dns.c \
-	../src/example.c \
-	../src/ipfix.c \
-	../src/ssh.c \
-	../src/ike.c \
-	../src/salt.c \
-	../src/parson.c \
-	../src/fingerprint.c \
-	../src/ppi.c \
-	../src/utils.c \
-	../src/dhcp.c \
-	../src/payload.c \
-	../src/config.c \
-	../src/proto_identify.c \
-	../src/fp.c \
-	../src/extractor.c \
-	../src/include/acsm.h \
-		../src/include/addr_attr.h \
-		../src/include/addr.h \
-		../src/include/anon.h \
-		../src/include/classify.h \
-		../src/include/config.h \
-		../src/include/dhcp.h \
-		../src/include/dns.h \
-		../src/include/err.h \
-		../src/include/example.h \
-		../src/include/feature.h \
-		../src/include/fingerprint.h \
-		../src/include/hdr_dsc.h \
-		../src/include/http.h \
-		../src/include/ike.h \
-		../src/include/ipfix.h \
-		../src/include/joy_api.h \
-		../src/include/joy_api_private.h \
-		../src/include/map.h \
-		../src/include/modules.h \
-		../src/include/nfv9.h \
-		../src/include/osdetect.h \
-		../src/include/output.h \
-		../src/include/p2f.h \
-		../src/include/parson.h \
-		../src/include/payload.h \
-		../src/include/pkt.h \
-		../src/include/pkt_proc.h \
-		../src/include/ppi.h \
-		../src/include/procwatch.h \
-		../src/include/proto_identify.h \
-		../src/include/radix_trie.h \
-		../src/include/salt.h \
-		../src/include/ssh.h \
-		../src/include/str_match.h \
-		../src/include/tls.h \
-		../src/include/updater.h \
-		../src/include/utils.h \
-		../src/include/fp.h \
-		../src/include/extractor.h \
-		../src/include/wht.h \
-		../src/include/fp.h \
-		../src/include/extractor.h
+@BUILD_WITH_SAFEC_FALSE@libjoy_la_SOURCES = \
+@BUILD_WITH_SAFEC_FALSE@	../src/joy_api.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/p2f.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/osdetect.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/anon.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/pkt_proc.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/nfv9.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/tls.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/classify.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/radix_trie.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/hdr_dsc.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/procwatch.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/addr_attr.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/addr.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/wht.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/http.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/str_match.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/acsm.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/dns.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/example.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/ipfix.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/ssh.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/ike.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/salt.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/parson.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/fingerprint.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/ppi.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/utils.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/dhcp.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/payload.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/config.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/proto_identify.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/fp.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/extractor.c \
+@BUILD_WITH_SAFEC_FALSE@	../safe_c_stub/src/safe_str_stub.c \
+@BUILD_WITH_SAFEC_FALSE@	../safe_c_stub/src/safe_mem_stub.c \
+@BUILD_WITH_SAFEC_FALSE@	../src/include/acsm.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/addr_attr.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/addr.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/anon.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/classify.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/config.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/dhcp.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/dns.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/err.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/example.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/feature.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/fingerprint.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/hdr_dsc.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/http.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/ike.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/ipfix.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/joy_api.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/joy_api_private.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/map.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/modules.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/nfv9.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/osdetect.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/output.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/p2f.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/parson.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/payload.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/pkt.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/pkt_proc.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/ppi.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/procwatch.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/proto_identify.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/radix_trie.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/salt.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/ssh.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/str_match.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/tls.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/updater.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/utils.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/fp.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/extractor.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/wht.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/fp.h \
+@BUILD_WITH_SAFEC_FALSE@		../src/include/extractor.h
 
-@BUILD_WITH_SAFEC_FALSE@libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lstubsafec
-@BUILD_WITH_SAFEC_TRUE@libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lciscosafec
+@BUILD_WITH_SAFEC_TRUE@libjoy_la_SOURCES = \
+@BUILD_WITH_SAFEC_TRUE@	../src/joy_api.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/p2f.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/osdetect.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/anon.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/pkt_proc.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/nfv9.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/tls.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/classify.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/radix_trie.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/hdr_dsc.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/procwatch.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/addr_attr.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/addr.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/wht.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/http.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/str_match.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/acsm.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/dns.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/example.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/ipfix.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/ssh.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/ike.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/salt.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/parson.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/fingerprint.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/ppi.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/utils.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/dhcp.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/payload.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/config.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/proto_identify.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/fp.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/extractor.c \
+@BUILD_WITH_SAFEC_TRUE@	../src/include/acsm.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/addr_attr.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/addr.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/anon.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/classify.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/config.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/dhcp.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/dns.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/err.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/example.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/feature.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/fingerprint.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/hdr_dsc.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/http.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/ike.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/ipfix.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/joy_api.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/joy_api_private.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/map.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/modules.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/nfv9.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/osdetect.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/output.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/p2f.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/parson.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/payload.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/pkt.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/pkt_proc.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/ppi.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/procwatch.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/proto_identify.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/radix_trie.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/salt.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/ssh.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/str_match.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/tls.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/updater.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/utils.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/fp.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/extractor.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/wht.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/fp.h \
+@BUILD_WITH_SAFEC_TRUE@		../src/include/extractor.h
+
 libjoy_la_CFLAGS = -I ../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include -I $(SAFEC_DIR)/include/safec
-libjoy_la_LDFLAGS = -version-info $(JOY_LIBRARY_VERSION) $(SSL_LDFLAGS) -lcrypto
 library_includedir = $(includedir)/joy
 library_include_HEADERS = \
 		../src/include/acsm.h \
@@ -364,6 +528,9 @@ library_include_HEADERS = \
 		../src/include/fp.h \
 		../src/include/extractor.h
 
+@BUILD_WITH_SAFEC_FALSE@libjoy_la_LIBADD = $(SSL_LDFLAGS) -lcrypto
+@BUILD_WITH_SAFEC_TRUE@libjoy_la_LIBADD = -L$(SAFEC_DIR)/lib -lciscosafec
+libjoy_la_LDFLAGS = -version-info $(JOY_LIBRARY_VERSION) $(SSL_LDFLAGS) -lcrypto 
 all: all-am
 
 .SUFFIXES:
@@ -501,11 +668,27 @@ clean-libLTLIBRARIES:
 	../src/$(DEPDIR)/$(am__dirstamp)
 ../src/libjoy_la-extractor.lo: ../src/$(am__dirstamp) \
 	../src/$(DEPDIR)/$(am__dirstamp)
+../safe_c_stub/src/$(am__dirstamp):
+	@$(MKDIR_P) ../safe_c_stub/src
+	@: > ../safe_c_stub/src/$(am__dirstamp)
+../safe_c_stub/src/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) ../safe_c_stub/src/$(DEPDIR)
+	@: > ../safe_c_stub/src/$(DEPDIR)/$(am__dirstamp)
+../safe_c_stub/src/libjoy_la-safe_str_stub.lo:  \
+	../safe_c_stub/src/$(am__dirstamp) \
+	../safe_c_stub/src/$(DEPDIR)/$(am__dirstamp)
+../safe_c_stub/src/libjoy_la-safe_mem_stub.lo:  \
+	../safe_c_stub/src/$(am__dirstamp) \
+	../safe_c_stub/src/$(DEPDIR)/$(am__dirstamp)
 libjoy.la: $(libjoy_la_OBJECTS) $(libjoy_la_DEPENDENCIES) 
 	$(libjoy_la_LINK) -rpath $(libdir) $(libjoy_la_OBJECTS) $(libjoy_la_LIBADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
+	-rm -f ../safe_c_stub/src/libjoy_la-safe_mem_stub.$(OBJEXT)
+	-rm -f ../safe_c_stub/src/libjoy_la-safe_mem_stub.lo
+	-rm -f ../safe_c_stub/src/libjoy_la-safe_str_stub.$(OBJEXT)
+	-rm -f ../safe_c_stub/src/libjoy_la-safe_str_stub.lo
 	-rm -f ../src/libjoy_la-acsm.$(OBJEXT)
 	-rm -f ../src/libjoy_la-acsm.lo
 	-rm -f ../src/libjoy_la-addr.$(OBJEXT)
@@ -576,6 +759,8 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_mem_stub.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_str_stub.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/libjoy_la-acsm.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/libjoy_la-addr.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/libjoy_la-addr_attr.Plo@am__quote@
@@ -865,11 +1050,26 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libjoy_la_CFLAGS) $(CFLAGS) -c -o ../src/libjoy_la-extractor.lo `test -f '../src/extractor.c' || echo '$(srcdir)/'`../src/extractor.c
 
+../safe_c_stub/src/libjoy_la-safe_str_stub.lo: ../safe_c_stub/src/safe_str_stub.c
+@am__fastdepCC_TRUE@	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libjoy_la_CFLAGS) $(CFLAGS) -MT ../safe_c_stub/src/libjoy_la-safe_str_stub.lo -MD -MP -MF ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_str_stub.Tpo -c -o ../safe_c_stub/src/libjoy_la-safe_str_stub.lo `test -f '../safe_c_stub/src/safe_str_stub.c' || echo '$(srcdir)/'`../safe_c_stub/src/safe_str_stub.c
+@am__fastdepCC_TRUE@	$(am__mv) ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_str_stub.Tpo ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_str_stub.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	source='../safe_c_stub/src/safe_str_stub.c' object='../safe_c_stub/src/libjoy_la-safe_str_stub.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libjoy_la_CFLAGS) $(CFLAGS) -c -o ../safe_c_stub/src/libjoy_la-safe_str_stub.lo `test -f '../safe_c_stub/src/safe_str_stub.c' || echo '$(srcdir)/'`../safe_c_stub/src/safe_str_stub.c
+
+../safe_c_stub/src/libjoy_la-safe_mem_stub.lo: ../safe_c_stub/src/safe_mem_stub.c
+@am__fastdepCC_TRUE@	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libjoy_la_CFLAGS) $(CFLAGS) -MT ../safe_c_stub/src/libjoy_la-safe_mem_stub.lo -MD -MP -MF ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_mem_stub.Tpo -c -o ../safe_c_stub/src/libjoy_la-safe_mem_stub.lo `test -f '../safe_c_stub/src/safe_mem_stub.c' || echo '$(srcdir)/'`../safe_c_stub/src/safe_mem_stub.c
+@am__fastdepCC_TRUE@	$(am__mv) ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_mem_stub.Tpo ../safe_c_stub/src/$(DEPDIR)/libjoy_la-safe_mem_stub.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	source='../safe_c_stub/src/safe_mem_stub.c' object='../safe_c_stub/src/libjoy_la-safe_mem_stub.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libjoy_la_CFLAGS) $(CFLAGS) -c -o ../safe_c_stub/src/libjoy_la-safe_mem_stub.lo `test -f '../safe_c_stub/src/safe_mem_stub.c' || echo '$(srcdir)/'`../safe_c_stub/src/safe_mem_stub.c
+
 mostlyclean-libtool:
 	-rm -f *.lo
 
 clean-libtool:
 	-rm -rf .libs _libs
+	-rm -rf ../safe_c_stub/src/.libs ../safe_c_stub/src/_libs
 	-rm -rf ../src/.libs ../src/_libs
 install-library_includeHEADERS: $(library_include_HEADERS)
 	@$(NORMAL_INSTALL)
@@ -1002,6 +1202,8 @@ clean-generic:
 distclean-generic:
 	-test -z "$(CONFIG_CLEAN_FILES)" || rm -f $(CONFIG_CLEAN_FILES)
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
+	-rm -f ../safe_c_stub/src/$(DEPDIR)/$(am__dirstamp)
+	-rm -f ../safe_c_stub/src/$(am__dirstamp)
 	-rm -f ../src/$(DEPDIR)/$(am__dirstamp)
 	-rm -f ../src/$(am__dirstamp)
 
@@ -1014,7 +1216,7 @@ clean-am: clean-generic clean-libLTLIBRARIES clean-libtool \
 	mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ../src/$(DEPDIR)
+	-rm -rf ../safe_c_stub/src/$(DEPDIR) ../src/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -1060,7 +1262,7 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ../src/$(DEPDIR)
+	-rm -rf ../safe_c_stub/src/$(DEPDIR) ../src/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 


### PR DESCRIPTION
I made change to just build with safec stubs by default so the .a isn't required for libjoy.a