### PR TITLE
Add configuration and setup for running musebot

### DIFF
--- a/.muse/config
+++ b/.muse/config
@@ -1,0 +1,3 @@
+setup = ".muse/setup.sh"
+build = "make"
+verifiers = [ "infer" ]

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,5 @@
+if [ $(whoami) = "root" ]; then
+    apt install -y libpcap-dev
+fi
+
+cd $1 ; ./configure


### PR DESCRIPTION
This configuration file instructs muse to

1. Run a setup that installs pcap and runs configuration
2. Explicitly use make, just to side-step the autodetect logic and make things rock solid.
3. Explicitly use the infer checker.

I see `joy`, as with the `cisco/libacvp` project, has given musedev webhook events so with these changes you should see meaningful reports from the analysis.

N.B. the bot is likely to respond to this pull request with a failure because the pre-PR branch (aka master) does not build due to the default analysis image lacking libpcap-dev.