### PR TITLE
 fix bug in DNS output, fix static linking of joy conflicts

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -562,13 +562,13 @@ static void dns_print_packet (char *dns_name, unsigned int pkt_len, zfile output
         err = dns_header_parse_name(rh, &r, &len, name, sizeof(name));
         if (err != dns_ok) { 
             zprintf(output, "\"malformed\":%d", len);
-            zprintf_debug(output, "question name err=%u; len=%u\"}]}", err, len);
+            zprintf_debug(output, "question name err=%u; len=%u\"}", err, len);
             return;
         }
         err = dns_question_parse(&question, &r, &len);
         if (err != dns_ok) {
             zprintf(output, "\"malformed\":%d", len);
-            zprintf_debug(output, "question err=%u; len=%u\"]}]", err, len);
+            zprintf_debug(output, "question err=%u; len=%u\"}", err, len);
             return;
         }
         zprintf(output, "\"%cn\":\"%s\",", qr, name + 1);

--- a/src/joy.c
+++ b/src/joy.c
@@ -134,11 +134,11 @@ static pthread_mutex_t thrd_lock[MAX_JOY_THREADS] =
    PTHREAD_MUTEX_INITIALIZER};
 
 /* config is the global configuration */
-configuration_t active_config;
-configuration_t *glb_config = NULL;
+extern configuration_t active_config;
+extern configuration_t *glb_config;
 
 /* logfile definitions */
-FILE *info = NULL;
+extern FILE *info;
 
 /*
  * reopenLog is the flag set when SIGHUP is received


### PR DESCRIPTION
 fix bug in DNS output, fix static linking of joy (double defined variables when linked against library statically).