### PR TITLE
remove debug code causing a SIGBUS error on IPv6 DNS responses

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -433,15 +433,8 @@ static enum dns_err dns_header_parse_name (const dns_hdr *hdr, char **name, int 
                 /* advance pointers, decrease lengths */
                 outname_len -= jump;
                 *len -= jump;
-
-                /* sanity check to make sure we don't go past the data avilable */
-                if ((c + jump) <= (c + offsetlen)) {
-                    c += jump;
-                    *name += jump;
-                } else {
-                    /* would increment past available buffer */
-                    return dns_err_offset_too_long;
-                }
+                c += jump;
+                *name += jump;
             } else {
                 return dns_err_label_too_long;
             }
@@ -714,9 +707,8 @@ static void dns_print_packet (char *dns_name, unsigned int pkt_len, zfile output
         /* parse rr name, struct, and rdata */
         err = dns_header_parse_name(rh, &r, &len, name, (DNS_OUTNAME_LEN-1));
         if (err != dns_ok) { 
-            char *d = r;
             zprintf(output, "\"malformed\":%d", len);
-            zprintf_debug(output, "rr name ancount=%u; err=%u; len=%u; data=0x%02x%02x%02x%02x\"}]}", ancount, err, len, d[0], d[1], d[2], d[3]);
+            zprintf_debug(output, "rr name ancount=%u; err=%u; len=%u\"}]}", ancount, err, len);
             return;
         }
         err = dns_rr_parse(&rr, &r, &len, &rdlength);
@@ -751,9 +743,8 @@ static void dns_print_packet (char *dns_name, unsigned int pkt_len, zfile output
         /* parse rr name, struct, and rdata */
         err = dns_header_parse_name(rh, &r, &len, name, (DNS_OUTNAME_LEN-1));
         if (err != dns_ok) {
-            char *d = r;
             zprintf(output, "\"malformed\":%d", len);
-            zprintf_debug(output, "rr name nscount=%u; err=%u; len=%u; data=0x%02x%02x%02x%02x\"}]}", nscount, err, len, d[0], d[1], d[2], d[3]);
+            zprintf_debug(output, "rr name nscount=%u; err=%u; len=%u\"}]}", nscount, err, len);
             return;
         }
         err = dns_rr_parse(&rr, &r, &len, &rdlength);
@@ -781,9 +772,8 @@ static void dns_print_packet (char *dns_name, unsigned int pkt_len, zfile output
         /* parse rr name, struct, and rdata */
         err = dns_header_parse_name(rh, &r, &len, name, (DNS_OUTNAME_LEN-1));
         if (err != dns_ok) {
-            char *d = r;
             zprintf(output, "\"malformed\":%d", len);
-            zprintf_debug(output, "rr name arcount=%u; err=%u; len=%u; data=0x%02x%02x%02x%02x\"}]}", arcount, err, len, d[0], d[1], d[2], d[3]);
+            zprintf_debug(output, "rr name arcount=%u; err=%u; len=%u\"}]}", arcount, err, len);
             return;
         }
         err = dns_rr_parse(&rr, &r, &len, &rdlength);

--- a/src/dns.c
+++ b/src/dns.c
@@ -433,8 +433,15 @@ static enum dns_err dns_header_parse_name (const dns_hdr *hdr, char **name, int 
                 /* advance pointers, decrease lengths */
                 outname_len -= jump;
                 *len -= jump;
-                c += jump;
-                *name += jump;
+
+                /* sanity check to make sure we don't go past the data avilable */
+                if ((c + jump) <= (c + offsetlen)) {
+                    c += jump;
+                    *name += jump;
+                } else {
+                    /* would increment past available buffer */
+                    return dns_err_offset_too_long;
+                }
             } else {
                 return dns_err_label_too_long;
             }


### PR DESCRIPTION
remove debug code causing a SIGBUS error on IPv6 DNS responses