### PR TITLE
Add new target to build joy statically with libjoy and safec

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,7 +1,8 @@
 
-bin_PROGRAMS = joy unit_test joy_api_test joy_api_test2 jfd-anon joy-anon str_match_test
+bin_PROGRAMS = joy joy_static unit_test joy_api_test joy_api_test2 jfd-anon joy-anon str_match_test
 
 joy_SOURCES = ../src/joy.c
+joy_static_SOURCES = ../src/joy.c
 unit_test_SOURCES = ../src/unit_test.c
 joy_api_test_SOURCES = ../src/joy_api_test.c
 joy_api_test2_SOURCES = ../src/joy_api_test2.c
@@ -23,11 +24,13 @@ str_match_test_SOURCES = ../src/str_match_test.c
 
 if BUILD_WITH_SAFEC
  SAFEC_LIB= -lciscosafec
+ SAFEC_LIB_A=$(SAFEC_DIR)/lib/libciscosafec.a
 else
  SAFEC_LIB_STUBS=$(SAFEC_DIR)/lib/libstubsafec.a
 endif
 
 joy_CFLAGS = -I../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
+joy_static_CFLAGS = -I../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
 unit_test_CFLAGS = -I../src/include  -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
 jfd_anon_CFLAGS = -I../src/include  -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec 
 joy_anon_CFLAGS = -I../src/include  -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
@@ -37,6 +40,7 @@ str_match_test_CFLAGS = -I../src/include -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(S
 
 if BUILD_MAC
 joy_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -L../lib/.libs -ljoy -lm -lpcap -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
+joy_static_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -lm -lpcap -Wl,-pie
 unit_test_LDFLAGS = -lm -lpcap -L../lib/.libs -ljoy -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
 joy_anon_LDFLAGS = $(SSL_LDFLAGS) -lcrypto  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
 jfd_anon_LDFLAGS = $(SSL_LDFLAGS) -lcrypto  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
@@ -47,6 +51,7 @@ joy_api_test2_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -L../lib/.libs -ljoy -
 
 else
 joy_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -L../lib/.libs -ljoy -lm -lpcap  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
+joy_static_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -lm -lpcap -pie
 unit_test_LDFLAGS = $(LDFLAGS) -L../lib/.libs -ljoy -lm -lpcap -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
 joy_anon_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
 jfd_anon_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
@@ -56,6 +61,7 @@ joy_api_test2_LDFLAGS= $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -L../lib/.libs -ljoy -
 
 endif
 joy_LDADD=$(SAFEC_LIB_STUBS)
+joy_static_LDADD=../lib/.libs/libjoy.a $(SAFEC_LIB_STUBS) $(SAFEC_LIB_A) 
 unit_test_LDADD=$(SAFEC_LIB_STUBS)
 joy_anon_LDADD=$(SAFEC_LIB_STUBS)
 jfd_anon_LDADD=$(SAFEC_LIB_STUBS)

--- a/bin/Makefile.in
+++ b/bin/Makefile.in
@@ -78,9 +78,9 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-bin_PROGRAMS = joy$(EXEEXT) unit_test$(EXEEXT) joy_api_test$(EXEEXT) \
-	joy_api_test2$(EXEEXT) jfd-anon$(EXEEXT) joy-anon$(EXEEXT) \
-	str_match_test$(EXEEXT)
+bin_PROGRAMS = joy$(EXEEXT) joy_static$(EXEEXT) unit_test$(EXEEXT) \
+	joy_api_test$(EXEEXT) joy_api_test2$(EXEEXT) jfd-anon$(EXEEXT) \
+	joy-anon$(EXEEXT) str_match_test$(EXEEXT)
 subdir = bin
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/depcomp
@@ -140,6 +140,13 @@ joy_api_test2_DEPENDENCIES = $(SAFEC_LIB_STUBS)
 joy_api_test2_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(joy_api_test2_CFLAGS) \
 	$(CFLAGS) $(joy_api_test2_LDFLAGS) $(LDFLAGS) -o $@
+am_joy_static_OBJECTS = ../src/joy_static-joy.$(OBJEXT)
+joy_static_OBJECTS = $(am_joy_static_OBJECTS)
+joy_static_DEPENDENCIES = ../lib/.libs/libjoy.a $(SAFEC_LIB_STUBS) \
+	$(SAFEC_LIB_A)
+joy_static_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(joy_static_CFLAGS) \
+	$(CFLAGS) $(joy_static_LDFLAGS) $(LDFLAGS) -o $@
 am_str_match_test_OBJECTS =  \
 	../src/str_match_test-str_match_test.$(OBJEXT)
 str_match_test_OBJECTS = $(am_str_match_test_OBJECTS)
@@ -190,10 +197,12 @@ am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
 SOURCES = $(jfd_anon_SOURCES) $(joy_SOURCES) $(joy_anon_SOURCES) \
 	$(joy_api_test_SOURCES) $(joy_api_test2_SOURCES) \
-	$(str_match_test_SOURCES) $(unit_test_SOURCES)
+	$(joy_static_SOURCES) $(str_match_test_SOURCES) \
+	$(unit_test_SOURCES)
 DIST_SOURCES = $(jfd_anon_SOURCES) $(joy_SOURCES) $(joy_anon_SOURCES) \
 	$(joy_api_test_SOURCES) $(joy_api_test2_SOURCES) \
-	$(str_match_test_SOURCES) $(unit_test_SOURCES)
+	$(joy_static_SOURCES) $(str_match_test_SOURCES) \
+	$(unit_test_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -348,6 +357,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 joy_SOURCES = ../src/joy.c
+joy_static_SOURCES = ../src/joy.c
 unit_test_SOURCES = ../src/unit_test.c
 joy_api_test_SOURCES = ../src/joy_api_test.c
 joy_api_test2_SOURCES = ../src/joy_api_test2.c
@@ -367,8 +377,10 @@ joy_anon_SOURCES = \
 
 str_match_test_SOURCES = ../src/str_match_test.c
 @BUILD_WITH_SAFEC_TRUE@SAFEC_LIB = -lciscosafec
+@BUILD_WITH_SAFEC_TRUE@SAFEC_LIB_A = $(SAFEC_DIR)/lib/libciscosafec.a
 @BUILD_WITH_SAFEC_FALSE@SAFEC_LIB_STUBS = $(SAFEC_DIR)/lib/libstubsafec.a
 joy_CFLAGS = -I../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
+joy_static_CFLAGS = -I../src/include -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
 unit_test_CFLAGS = -I../src/include  -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
 jfd_anon_CFLAGS = -I../src/include  -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec 
 joy_anon_CFLAGS = -I../src/include  -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
@@ -377,6 +389,8 @@ joy_api_test2_CFLAGS = -I../src/include -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SS
 str_match_test_CFLAGS = -I../src/include -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(SSL_CFLAGS) $(AM_CFLAGS) -I $(SAFEC_DIR)/include  -I $(SAFEC_DIR)/include/safec
 @BUILD_MAC_FALSE@joy_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -L../lib/.libs -ljoy -lm -lpcap  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
 @BUILD_MAC_TRUE@joy_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -L../lib/.libs -ljoy -lm -lpcap -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
+@BUILD_MAC_FALSE@joy_static_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -lm -lpcap -pie
+@BUILD_MAC_TRUE@joy_static_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -lpthread -lm -lpcap -Wl,-pie
 @BUILD_MAC_FALSE@unit_test_LDFLAGS = $(LDFLAGS) -L../lib/.libs -ljoy -lm -lpcap -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
 @BUILD_MAC_TRUE@unit_test_LDFLAGS = -lm -lpcap -L../lib/.libs -ljoy -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
 @BUILD_MAC_FALSE@joy_anon_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
@@ -390,6 +404,7 @@ str_match_test_CFLAGS = -I../src/include -DFORCED_COMPRESSED_OUTPUT_OFF=1 -I $(S
 @BUILD_MAC_FALSE@joy_api_test2_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -L../lib/.libs -ljoy -lm -lpcap  -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -pie
 @BUILD_MAC_TRUE@joy_api_test2_LDFLAGS = $(LDFLAGS) $(SSL_LDFLAGS) -lcrypto -L../lib/.libs -ljoy -lm -lpcap -L$(SAFEC_DIR)/lib $(SAFEC_LIB) -Wl,-pie
 joy_LDADD = $(SAFEC_LIB_STUBS)
+joy_static_LDADD = ../lib/.libs/libjoy.a $(SAFEC_LIB_STUBS) $(SAFEC_LIB_A) 
 unit_test_LDADD = $(SAFEC_LIB_STUBS)
 joy_anon_LDADD = $(SAFEC_LIB_STUBS)
 jfd_anon_LDADD = $(SAFEC_LIB_STUBS)
@@ -531,6 +546,12 @@ joy_api_test$(EXEEXT): $(joy_api_test_OBJECTS) $(joy_api_test_DEPENDENCIES) $(EX
 joy_api_test2$(EXEEXT): $(joy_api_test2_OBJECTS) $(joy_api_test2_DEPENDENCIES) $(EXTRA_joy_api_test2_DEPENDENCIES) 
 	@rm -f joy_api_test2$(EXEEXT)
 	$(AM_V_CCLD)$(joy_api_test2_LINK) $(joy_api_test2_OBJECTS) $(joy_api_test2_LDADD) $(LIBS)
+../src/joy_static-joy.$(OBJEXT): ../src/$(am__dirstamp) \
+	../src/$(DEPDIR)/$(am__dirstamp)
+
+joy_static$(EXEEXT): $(joy_static_OBJECTS) $(joy_static_DEPENDENCIES) $(EXTRA_joy_static_DEPENDENCIES) 
+	@rm -f joy_static$(EXEEXT)
+	$(AM_V_CCLD)$(joy_static_LINK) $(joy_static_OBJECTS) $(joy_static_LDADD) $(LIBS)
 ../src/str_match_test-str_match_test.$(OBJEXT):  \
 	../src/$(am__dirstamp) ../src/$(DEPDIR)/$(am__dirstamp)
 
@@ -564,6 +585,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/joy_anon-str_match.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/joy_api_test-joy_api_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/joy_api_test2-joy_api_test2.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/joy_static-joy.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/str_match_test-str_match_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@../src/$(DEPDIR)/unit_test-unit_test.Po@am__quote@
 
@@ -772,6 +794,20 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='../src/joy_api_test2.c' object='../src/joy_api_test2-joy_api_test2.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(joy_api_test2_CFLAGS) $(CFLAGS) -c -o ../src/joy_api_test2-joy_api_test2.obj `if test -f '../src/joy_api_test2.c'; then $(CYGPATH_W) '../src/joy_api_test2.c'; else $(CYGPATH_W) '$(srcdir)/../src/joy_api_test2.c'; fi`
+
+../src/joy_static-joy.o: ../src/joy.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(joy_static_CFLAGS) $(CFLAGS) -MT ../src/joy_static-joy.o -MD -MP -MF ../src/$(DEPDIR)/joy_static-joy.Tpo -c -o ../src/joy_static-joy.o `test -f '../src/joy.c' || echo '$(srcdir)/'`../src/joy.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) ../src/$(DEPDIR)/joy_static-joy.Tpo ../src/$(DEPDIR)/joy_static-joy.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='../src/joy.c' object='../src/joy_static-joy.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(joy_static_CFLAGS) $(CFLAGS) -c -o ../src/joy_static-joy.o `test -f '../src/joy.c' || echo '$(srcdir)/'`../src/joy.c
+
+../src/joy_static-joy.obj: ../src/joy.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(joy_static_CFLAGS) $(CFLAGS) -MT ../src/joy_static-joy.obj -MD -MP -MF ../src/$(DEPDIR)/joy_static-joy.Tpo -c -o ../src/joy_static-joy.obj `if test -f '../src/joy.c'; then $(CYGPATH_W) '../src/joy.c'; else $(CYGPATH_W) '$(srcdir)/../src/joy.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) ../src/$(DEPDIR)/joy_static-joy.Tpo ../src/$(DEPDIR)/joy_static-joy.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='../src/joy.c' object='../src/joy_static-joy.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(joy_static_CFLAGS) $(CFLAGS) -c -o ../src/joy_static-joy.obj `if test -f '../src/joy.c'; then $(CYGPATH_W) '../src/joy.c'; else $(CYGPATH_W) '$(srcdir)/../src/joy.c'; fi`
 
 ../src/str_match_test-str_match_test.o: ../src/str_match_test.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(str_match_test_CFLAGS) $(CFLAGS) -MT ../src/str_match_test-str_match_test.o -MD -MP -MF ../src/$(DEPDIR)/str_match_test-str_match_test.Tpo -c -o ../src/str_match_test-str_match_test.o `test -f '../src/str_match_test.c' || echo '$(srcdir)/'`../src/str_match_test.c


### PR DESCRIPTION
I added a new target joy_static that will create a binary including libjoy and safec so you don't need to have these on your host that is running it.