### PR TITLE
added requirements.txt and now fingerprint_ui.py works on Windows

### DIFF
--- a/fingerprinting/fingerprinter.py
+++ b/fingerprinting/fingerprinter.py
@@ -50,7 +50,8 @@ import socket
 import datetime
 import optparse
 from collections import OrderedDict
-
+if os.name == 'nt':
+    import win_inet_pton
 from tls_fingerprint import TLSFingerprint
 
 class Fingerprinter:

--- a/fingerprinting/requirements.txt
+++ b/fingerprinting/requirements.txt
@@ -1,0 +1,4 @@
+bottle
+dpkt
+pypcap
+numpy

--- a/fingerprinting/requirements_windows.txt
+++ b/fingerprinting/requirements_windows.txt
@@ -1,0 +1,1 @@
+win_inet_pton

--- a/fingerprinting/views/detailed_fp.tpl
+++ b/fingerprinting/views/detailed_fp.tpl
@@ -72,7 +72,7 @@ th {
       <tr>
         <td>{{fp_['fingerprint']['process_info'][i]['prevalence']}}</td>
         <td>{{fp_['fingerprint']['process_info'][i]['process']}}</td>
-        <td>{{fp_['fingerprint']['process_info'][i]['application_category']}}</td>
+        <td>{{fp_['fingerprint']['process_info'][i].get('application_category')}}</td>
         <td>{{fp_['fingerprint']['process_info'][i]['sha256']}}</td>
       </tr>
     % end


### PR DESCRIPTION
There is a very small fix. Have tested manually.

> Description: win_inet_pton
=============
Native inet_pton and inet_ntop implementation for Python on Windows (with ctypes).